### PR TITLE
[runtime] Integrate snitch runtime into the quidditch runtime

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "iree"]
 	path = iree
 	url = https://github.com/iree-org/iree
+[submodule "snitch_cluster"]
+	path = snitch_cluster
+	url = https://github.com/pulp-platform/snitch_cluster

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,7 +1,9 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
+
 project(QuidditchRuntime LANGUAGES C ASM)
 
 set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE STRING "IREE source code path")
+set(SNITCH_CLUSTER_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../snitch_cluster" CACHE STRING "snitch_cluster source code path")
 set(QUIDDITCH_CODEGEN_BUILD_DIR "" CACHE STRING "CMake generation directory with a compiled 'iree-compile'")
 
 list(APPEND CMAKE_MODULE_PATH
@@ -15,4 +17,9 @@ add_definitions(-DIREE_PLATFORM_GENERIC)
 add_definitions(-DIREE_USER_CONFIG_H="${CMAKE_CURRENT_LIST_DIR}/iree-configuration/config.h")
 add_subdirectory(iree-configuration)
 
+add_subdirectory(snitch_cluster SYSTEM EXCLUDE_FROM_ALL)
+
 add_subdirectory(samples)
+
+enable_testing()
+add_subdirectory(tests)

--- a/runtime/samples/CMakeLists.txt
+++ b/runtime/samples/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(IREE_HelloWorld main.c)
 target_link_libraries(
         IREE_HelloWorld
         PRIVATE
+        snRuntime
         iree::base
         iree::vm
         iree::modules::hal

--- a/runtime/snitch_cluster/CMakeLists.txt
+++ b/runtime/snitch_cluster/CMakeLists.txt
@@ -1,0 +1,74 @@
+project(snRuntime C ASM)
+
+# Required for running regtool and clustergen.
+find_package(Python3 REQUIRED)
+# Required for finding regtool.
+find_program(bender_path NAMES bender REQUIRED)
+
+set(SNITCH_RUNTIME_TARGET "rtl" CACHE STRING "Snitch runtime target to use")
+
+set(snRuntimeSrc ${SNITCH_CLUSTER_SOURCE_DIR})
+set(header_dir ${CMAKE_CURRENT_BINARY_DIR}/cluster_gen)
+set(config_file ${snRuntimeSrc}/target/snitch_cluster/cfg/default.hjson)
+set(runtime_dir ${CMAKE_CURRENT_LIST_DIR}/${SNITCH_RUNTIME_TARGET})
+
+# Get the path of regtool from bender. This will additionally automatically
+# install it.
+execute_process(COMMAND ${bender_path} path register_interface
+    OUTPUT_VARIABLE reggen_base_path
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    WORKING_DIRECTORY ${snRuntimeSrc})
+set(reggen_path ${reggen_base_path}/vendor/lowrisc_opentitan/util/regtool.py)
+
+# Generate the 'snitch_cluster_peripheral.h' header.
+add_custom_command(OUTPUT "${header_dir}/snitch_cluster_peripheral.h"
+    COMMAND ${Python3_EXECUTABLE} ${reggen_path} -D
+    -o "${header_dir}/snitch_cluster_peripheral.h"
+    ${snRuntimeSrc}/hw/snitch_cluster/src/snitch_cluster_peripheral/snitch_cluster_peripheral_reg.hjson
+    WORKING_DIRECTORY ${snRuntimeSrc}
+    DEPENDS ${snRuntimeSrc}/hw/snitch_cluster/src/snitch_cluster_peripheral/snitch_cluster_peripheral_reg.hjson)
+add_custom_target(snitch_cluster_peripheral.h DEPENDS "${header_dir}/snitch_cluster_peripheral.h")
+
+add_custom_target(cluster_gen)
+macro(run_cluster_gen input_file)
+  set(filename ${input_file})
+  # Resulting filename is the input file name with the last extension removed.
+  # Usually transforms '*.h.tpl' to '*.h'.
+  cmake_path(GET filename FILENAME filename)
+  cmake_path(GET filename STEM LAST_ONLY filename)
+  add_custom_command(OUTPUT "${header_dir}/${filename}"
+      COMMAND ${Python3_EXECUTABLE} ${snRuntimeSrc}/util/clustergen.py
+      -c ${config_file} --outdir ${header_dir} --template ${input_file}
+      DEPENDS ${config_file} ${input_file}
+  )
+  add_custom_target(${filename}-target DEPENDS "${header_dir}/${filename}")
+  add_dependencies(cluster_gen ${filename}-target)
+endmacro()
+
+run_cluster_gen(${snRuntimeSrc}/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl)
+run_cluster_gen(${snRuntimeSrc}/target/snitch_cluster/sw/runtime/common/snitch_cluster_cfg.h.tpl)
+
+
+add_library(snRuntime
+    ${runtime_dir}/src/snitch_cluster_start.S
+    ${runtime_dir}/src/snrt.c
+    ${runtime_dir}/src/syscalls.c
+)
+target_include_directories(snRuntime PRIVATE
+    ${snRuntimeSrc}/target/snitch_cluster/sw/runtime/common/
+    ${snRuntimeSrc}/sw/snRuntime/src
+    ${snRuntimeSrc}/sw/snRuntime/src/omp
+    ${header_dir}
+    PUBLIC
+    ${snRuntimeSrc}/sw/snRuntime/api
+    ${snRuntimeSrc}/sw/snRuntime/api/omp
+)
+add_dependencies(snRuntime cluster_gen snitch_cluster_peripheral.h)
+target_link_options(snRuntime INTERFACE -Tbase.ld)
+target_link_directories(snRuntime
+    INTERFACE
+    ${snRuntimeSrc}/sw/snRuntime
+    ${runtime_dir}
+)
+# Required while snRuntime uses 'inline' qualifiers for declarations.
+target_compile_options(snRuntime PRIVATE -Wno-undefined-inline)

--- a/runtime/snitch_cluster/rtl/memory.ld
+++ b/runtime/snitch_cluster/rtl/memory.ld
@@ -1,0 +1,8 @@
+/* Copyright 2020 ETH Zurich and University of Bologna. */
+/* Solderpad Hardware License, Version 0.51, see LICENSE for details. */
+/* SPDX-License-Identifier: SHL-0.51 */
+
+MEMORY
+{
+    L3 (rwxa) : ORIGIN = 0x80000000, LENGTH = 0x80000000
+}

--- a/runtime/snitch_cluster/rtl/src/snitch_cluster_start.S
+++ b/runtime/snitch_cluster/rtl/src/snitch_cluster_start.S
@@ -1,0 +1,15 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+#define SNRT_INIT_INT_REGS
+#define SNRT_INIT_FP_REGS
+#define SNRT_INIT_GP
+#define SNRT_INIT_CORE_INFO
+#define SNRT_INIT_CLS
+#define SNRT_INIT_STACK
+#define SNRT_INIT_TLS
+#define SNRT_CRT0_PARK
+
+#include "snitch_cluster_defs.h"
+#include "start.S"

--- a/runtime/snitch_cluster/rtl/src/snitch_cluster_start.c
+++ b/runtime/snitch_cluster/rtl/src/snitch_cluster_start.c
@@ -1,0 +1,20 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define SNRT_INIT_TLS
+#define SNRT_INIT_BSS
+#define SNRT_INIT_CLS
+#define SNRT_INIT_LIBS
+#define SNRT_CRT0_PRE_BARRIER
+#define SNRT_INVOKE_MAIN
+#define SNRT_CRT0_POST_BARRIER
+#define SNRT_CRT0_EXIT
+
+extern uint32_t tohost;
+
+static inline volatile uint32_t* snrt_exit_code_destination() {
+  return (volatile uint32_t*)&tohost;
+}
+
+#include "start.c"

--- a/runtime/snitch_cluster/rtl/src/snrt.c
+++ b/runtime/snitch_cluster/rtl/src/snrt.c
@@ -1,0 +1,36 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "snrt.h"
+
+#include "alloc.c"
+#include "cls.c"
+#include "cluster_interrupts.c"
+#include "dma.c"
+#include "eu.c"
+#include "kmp.c"
+#include "printf.c"
+#include "riscv.c"
+#include "snitch_cluster_start.c"
+#include "sync.c"
+#include "team.c"
+
+// TODO: Remove declarations that are workarounds until
+//  https://github.com/pulp-platform/snitch_cluster/pull/136 landed.
+
+extern uint32_t snrt_l1_start_addr();
+extern uint32_t snrt_l1_end_addr();
+
+extern volatile uint32_t *snrt_zero_memory_ptr();
+
+extern cls_t* cls();
+
+extern snrt_allocator_t *snrt_l1_allocator();
+extern snrt_allocator_t *snrt_l3_allocator();
+
+extern uint32_t snrt_global_all_to_all_reduction(uint32_t value);
+
+extern uint32_t snrt_global_compute_core_num();
+
+extern uint32_t snrt_global_compute_core_idx();

--- a/runtime/snitch_cluster/rtl/src/snrt.h
+++ b/runtime/snitch_cluster/rtl/src/snrt.h
@@ -1,0 +1,37 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Snitch cluster specific
+#include "snitch_cluster_defs.h"
+#include "snitch_cluster_memory.h"
+
+// Forward declarations
+#include "alloc_decls.h"
+#include "cls_decls.h"
+#include "riscv_decls.h"
+#include "start_decls.h"
+#include "sync_decls.h"
+#include "team_decls.h"
+
+// Implementation
+#include "alloc.h"
+#include "cls.h"
+#include "cluster_interrupts.h"
+#include "dma.h"
+#include "dump.h"
+#include "eu.h"
+#include "kmp.h"
+#include "omp.h"
+#include "perf_cnt.h"
+#include "printf.h"
+#include "riscv.h"
+#include "snitch_cluster_global_interrupts.h"
+#include "ssr.h"
+#include "sync.h"
+#include "team.h"

--- a/runtime/snitch_cluster/rtl/src/syscalls.c
+++ b/runtime/snitch_cluster/rtl/src/syscalls.c
@@ -1,0 +1,56 @@
+#include <string.h>
+#include <sys/stat.h>
+
+#include "alloc_decls.h"
+#include "riscv_decls.h"
+#include "snitch_cluster_defs.h"
+#include "team_decls.h"
+
+int close(int fd) { return -1; }
+
+off_t lseek(int file, off_t offset, int whence) { return 0; }
+
+ssize_t read(int fd, void *buf, size_t count) { return 0; }
+
+extern uintptr_t volatile tohost, fromhost;
+
+// Verilator is not able to read any stack memory, but it is capable of reading
+// the bss section. Use a global buffer that any 'ptr' in '_write' is copied to.
+static struct Buffer {
+  uint64_t syscall_mem[8];
+  char verilatorReachable[120];
+} buffer[SNRT_CLUSTER_CORE_NUM];
+
+ssize_t write(int file, const void *ptr, size_t len) {
+  uint32_t id = snrt_hartid();
+  int old_len = len;
+
+  do {
+    unsigned to_write = len > sizeof(buffer[id].verilatorReachable)
+                            ? sizeof(buffer[id].verilatorReachable)
+                            : len;
+    memcpy(buffer[id].verilatorReachable, ptr, to_write);
+    buffer[id].syscall_mem[0] = 64;    // sys_write
+    buffer[id].syscall_mem[1] = file;  // file descriptor (1 = stdout)
+    buffer[id].syscall_mem[2] =
+        (uintptr_t)buffer[id].verilatorReachable;  // buffer
+    buffer[id].syscall_mem[3] = to_write;          // length
+
+    tohost = (uintptr_t)buffer[id].syscall_mem;
+    while (fromhost == 0)
+      ;
+    fromhost = 0;
+
+    len -= to_write;
+    ptr += to_write;
+  } while (len > 0);
+
+  return old_len;
+}
+
+void *sbrk(ptrdiff_t incr) { return snrt_l3alloc(incr); }
+
+void _exit(int exitCode) {
+  asm volatile("wfi");
+  __builtin_unreachable();
+}

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+include(CTest)
+
+# Sanity check that our toolchain, emulator etc. work
+add_executable(HelloWorld main.c)
+target_link_libraries(HelloWorld snRuntime)
+
+
+add_test(NAME HelloWorld COMMAND HelloWorld)

--- a/runtime/tests/main.c
+++ b/runtime/tests/main.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <team_decls.h>
+
+int main() {
+  if (!snrt_is_dm_core()) return 0;
+
+  printf("Hello World\n");
+  return 0;
+}


### PR DESCRIPTION
Building the snitch runtime as part of the monobuild ensures that we always use the same compiler, compilation flags and also gives us greater flexibility in assembling the parts from the snitch runtime that we need. In particular, changing the startup file to differently use the L1 of the compute cores will likely be required. Lastly, this makes it very easy to change the hardware config as it only requires changing the path to a hjson file within the cmake.

It is now possible to build and run a hello world as a check.