### PR TITLE
[build] Add convenient megabuild

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DPULP_CLANG_PATH=${{github.workspace}}/pulp-toolchain/bin/clang \
           -DQUIDDITCH_TOOLCHAIN_FILE=${{github.workspace}}/toolchain/ToolchainFile.cmake \
+          -DOVERRIDE_VENV=ON \
           -S ${{github.workspace}}
 
       - name: Build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,20 +35,10 @@ jobs:
             max_size=400M
             compiler_check=none
 
-      - name: Install Compiler
+      - name: Install Native Compilers
         run: |
           sudo apt-get update
-          sudo apt-get install lld clang
-
-      - name: Install Python dependencies
-        run: |
-          pip install -r requirements.txt
-
-      - name: Install bender
-        uses: baptiste0928/cargo-install@v3
-        with:
-          crate: bender
-          version: '~0.28.0'
+          sudo apt-get install lld clang cargo
 
       - name: Install Pulp Toolchain
         run: |
@@ -56,39 +46,26 @@ jobs:
           wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/0.12.0/riscv32-pulp-llvm-ubuntu2004-0.12.0.tar.gz \
           | tar --strip-components=1 -xzv -C ${{github.workspace}}/pulp-toolchain
 
-      - name: Configure Compiler
-        run: |
-          cmake -G Ninja -B ${{github.workspace}}/codegen/build \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_C_COMPILER=clang \
-          -DCMAKE_CXX_COMPILER=clang++ \
-          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-          -DIREE_ENABLE_ASSERTIONS=ON \
-          -DIREE_ENABLE_LLD=ON \
-          -DIREE_ENABLE_THIN_ARCHIVES=ON \
-          -DPULP_CLANG_PATH=${{github.workspace}}/pulp-toolchain/bin/clang \
-          -S ${{github.workspace}}/codegen
-
-      - name: Build and Test Compiler
-        run: cmake --build ${{github.workspace}}/codegen/build --target check-quidditch
-
-      - name: Download Quidditch Toolchain
+      - name: Install Quidditch Toolchain
         run: |
           mkdir ./toolchain
           docker run --rm ghcr.io/opencompl/quidditch/toolchain:main tar -cC /opt/quidditch-toolchain . \
           | tar -xC ./toolchain
 
-      - name: Configure Runtime
+      - name: Configure Megabuild
         run: |
-          cmake -GNinja -Bquidditch-runtime-build \
-          -DCMAKE_TOOLCHAIN_FILE=${{github.workspace}}/toolchain/ToolchainFile.cmake \
+          cmake -G Ninja -B ${{github.workspace}}/build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DPULP_CLANG_PATH=${{github.workspace}}/pulp-toolchain/bin/clang \
-          -S ${{github.workspace}}/runtime
+          -DQUIDDITCH_TOOLCHAIN_FILE=${{github.workspace}}/toolchain/ToolchainFile.cmake \
+          -S ${{github.workspace}}/codegen
 
-      - name: Build Runtime
-        run: cmake --build quidditch-runtime-build
+      - name: Build
+        run: cmake --build ${{github.workspace}}/build
 
-      - name: Test Runtime
-        working-directory: ${{github.workspace}}/quidditch-runtime-build
-        run: ctest --extra-verbose -j$(nproc)
+      - name: Test
+        run: cmake --build ${{github.workspace}}/build --target test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DPULP_CLANG_PATH=${{github.workspace}}/pulp-toolchain/bin/clang \
           -DQUIDDITCH_TOOLCHAIN_FILE=${{github.workspace}}/toolchain/ToolchainFile.cmake \
-          -S ${{github.workspace}}/codegen
+          -S ${{github.workspace}}
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,8 +65,5 @@ jobs:
           -DOVERRIDE_VENV=ON \
           -S ${{github.workspace}}
 
-      - name: Build
-        run: cmake --build ${{github.workspace}}/build
-
-      - name: Test
+      - name: Build and Test
         run: cmake --build ${{github.workspace}}/build --target test

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "xdsl"]
 	path = xdsl
 	url = https://github.com/xdslproject/xdsl
+[submodule "bender"]
+	path = bender
+	url = https://github.com/pulp-platform/bender

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required(VERSION 3.21)
+project(Quidditch C CXX)
+
+set(QUIDDITCH_TOOLCHAIN_FILE "" CACHE STRING "Path to the quidditch toolchain's toolchain file")
+set(PULP_CLANG_PATH "" CACHE STRING "Path to clang within the pulp toolchain")
+set(OVERRIDE_VENV OFF CACHE BOOL "")
+
+if (NOT DEFINED ENV{VIRTUAL_ENV} AND NOT ${OVERRIDE_VENV})
+  message(FATAL_ERROR [[
+  Please use a virtual environment as this cmake script will call pip install.
+  Reconfigure with -DOVERRIDE_VENV=ON if this is a false positive or you don't
+  care.
+]])
+  return()
+endif ()
+
+set(Python3_FIND_VIRTUALENV "FIRST")
+find_package(Python3 REQUIRED)
+execute_process(
+    COMMAND "${Python3_EXECUTABLE}" -m pip install -r ${CMAKE_CURRENT_LIST_DIR}/requirements.txt
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} COMMAND_ERROR_IS_FATAL ANY)
+
+find_program(CARGO_PATH cargo REQUIRED DOC "Path to cargo required to build bender")
+
+include(ExternalProject)
+
+macro(append_if_defined list variable)
+  if (DEFINED ${variable})
+    list(APPEND ${list} "-D${variable}=${${variable}}")
+  endif ()
+endmacro()
+
+set(host_cmake_args)
+append_if_defined(host_cmake_args CMAKE_BUILD_TYPE)
+append_if_defined(host_cmake_args CMAKE_C_COMPILER)
+append_if_defined(host_cmake_args CMAKE_CXX_COMPILER)
+append_if_defined(host_cmake_args CMAKE_C_COMPILER_LAUNCHER)
+append_if_defined(host_cmake_args CMAKE_CXX_COMPILER_LAUNCHER)
+ExternalProject_Add(codegen
+    CMAKE_ARGS
+    -DIREE_ENABLE_LLD=ON
+    -DPULP_CLANG_PATH=${PULP_CLANG_PATH}
+    ${host_cmake_args}
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/codegen
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/codegen
+    TEST_COMMAND ""
+    INSTALL_COMMAND ""
+    USES_TERMINAL_CONFIGURE ON
+    USES_TERMINAL_BUILD ON
+    USES_TERMINAL_TEST ON
+)
+
+ExternalProject_Add(bender
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bender
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND
+    ${CARGO_PATH} build
+    --release
+    --target-dir=${CMAKE_CURRENT_BINARY_DIR}/bender
+    --manifest-path=${CMAKE_CURRENT_LIST_DIR}/bender/Cargo.toml
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bender
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+    USES_TERMINAL_CONFIGURE ON
+    USES_TERMINAL_BUILD ON
+    USES_TERMINAL_TEST ON
+)
+
+set(runtime_cmake_args)
+append_if_defined(runtime_cmake_args CMAKE_BUILD_TYPE)
+append_if_defined(runtime_cmake_args CMAKE_C_COMPILER_LAUNCHER)
+append_if_defined(runtime_cmake_args CMAKE_CXX_COMPILER_LAUNCHER)
+ExternalProject_Add(runtime
+    CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${QUIDDITCH_TOOLCHAIN_FILE}
+    -DPULP_CLANG_PATH=${PULP_CLANG_PATH}
+    -DQUIDDITCH_CODEGEN_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}/codegen
+    -DBENDER_PATH=${CMAKE_CURRENT_BINARY_DIR}/bender/release/bender
+    ${runtime_cmake_args}
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/runtime
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/runtime
+    INSTALL_COMMAND ""
+    TEST_COMMAND ""
+    USES_TERMINAL_CONFIGURE ON
+    USES_TERMINAL_BUILD ON
+    USES_TERMINAL_TEST ON
+)
+add_dependencies(runtime codegen bender)
+
+include(ProcessorCount)
+ProcessorCount(N)
+
+enable_testing()
+include(CTest)
+set(CMAKE_CTEST_ARGUMENTS "--verbose")
+# lit uses maximum parallelism by default.
+add_test(NAME
+    codegen-tests
+    COMMAND
+    ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/codegen --target check-quidditch
+)
+add_test(NAME
+    runtime-tests
+    COMMAND
+    ${CMAKE_CTEST_COMMAND} --extra-verbose -j${N}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/runtime
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ ExternalProject_Add(codegen
     ${host_cmake_args}
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/codegen
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/codegen
+    BUILD_COMMAND ${CMAKE_COMMAND}
+    --build ${CMAKE_CURRENT_BINARY_DIR}/codegen
+    --target quidditch-test-depends
     TEST_COMMAND ""
     INSTALL_COMMAND ""
     USES_TERMINAL_CONFIGURE ON
@@ -60,7 +63,6 @@ ExternalProject_Add(bender
     --manifest-path=${CMAKE_CURRENT_LIST_DIR}/bender/Cargo.toml
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bender
     INSTALL_COMMAND ""
-    TEST_COMMAND ""
     USES_TERMINAL_CONFIGURE ON
     USES_TERMINAL_BUILD ON
     USES_TERMINAL_TEST ON
@@ -87,12 +89,15 @@ ExternalProject_Add(runtime
 )
 add_dependencies(runtime codegen bender)
 
+enable_testing()
 include(ProcessorCount)
 ProcessorCount(N)
 
-enable_testing()
 include(CTest)
 set(CMAKE_CTEST_ARGUMENTS "--verbose")
+file(CONFIGURE OUTPUT ${CMAKE_BINARY_DIR}/CTestCustom.cmake CONTENT [[
+set(CTEST_CUSTOM_PRE_TEST "@CMAKE_COMMAND@ --build @CMAKE_BINARY_DIR@")
+]] @ONLY)
 # lit uses maximum parallelism by default.
 add_test(NAME
     codegen-tests

--- a/README.md
+++ b/README.md
@@ -41,16 +41,13 @@ cmake .. -GNinja \
   # Optional but highly recommended 
   -DCMAKE_C_COMPILER=clang \
   -DCMAKE_CXX_COMPILER=clang++ \
-  -DCMAKE_CXX_COMPILER=clang++ \
   # Optional for improved caching, requires ccache to be installed.
   # -DCMAKE_C_COMPILER_LAUNCHER=ccache \
   # -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
   -DPULP_CLANG_PATH=$INSTALL_DIR/pulp-toolchain/bin/clang \
   -DQUIDDITCH_TOOLCHAIN_FILE=$INSTALL_DIR/quidditch-toolchain/ToolchainFile.cmake
   
-# Build everything:
-cmake --build .
-# Test everything. Requires everything to be built.
+# Build and Test everything.
 cmake --build . --target test
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Quidditch
+
+## Building
+
+Only linux is currently supported as a build environment
+
+Building Quidditch requires the following tools to be installed:
+* CMake 3.21 or newer
+* A C++17 compiler
+* Cargo
+* Python 3
+* Ninja (ideally)
+* the Quidditch toolchain
+* the Pulp toolchain
+
+`docker` is required to install the Quidditch toolchain using:
+```shell
+docker run --rm ghcr.io/opencompl/Quidditch/toolchain:main tar -cC /opt/quidditch-toolchain .\
+ | tar -xC $INSTALL_DIR/quidditch-toolchain
+```
+See [the toolchain directory for more details](runtime/toolchain/README.md).
+
+To get the pulp toolchain, you can run:
+```shell
+mkdir $INSTALL_DIR/pulp-toolchain
+wget -qO- https://github.com/pulp-platform/llvm-project/releases/download/0.12.0/riscv32-pulp-llvm-ubuntu2004-0.12.0.tar.gz \
+| tar --strip-components=1 -xzv -C $INSTALL_DIR/pulp-toolchain
+```
+or similar if your system is binary compatible with Ubuntu 22.04.
+
+Afterward, you can perform a mega build using:
+```shell
+git clone --recursive https://github.com/opencompl/quidditch
+cd quidditch
+
+python -m venv venv
+source ./venv/bin/activate
+
+mkdir build && cd build
+cmake .. -GNinja \
+  # Optional but highly recommended 
+  -DCMAKE_C_COMPILER=clang \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  # Optional for improved caching, requires ccache to be installed.
+  # -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  # -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DPULP_CLANG_PATH=$INSTALL_DIR/pulp-toolchain/bin/clang \
+  -DQUIDDITCH_TOOLCHAIN_FILE=$INSTALL_DIR/quidditch-toolchain/ToolchainFile.cmake
+  
+# Build everything:
+cmake --build .
+# Test everything. Requires everything to be built.
+cmake --build . --target test
+```
+
+This will execute both `codegen` and `runtime` builds as external builds of the top-level cmake.
+This is useful for quickly building and testing but may be undesirable for development.
+See the respective READMEs in [codegen](codegen/README.md) and [runtime](runtime/README.md) for how to configure them
+independently.

--- a/codegen/tests/CMakeLists.txt
+++ b/codegen/tests/CMakeLists.txt
@@ -41,10 +41,12 @@ foreach (_TOOL IN LISTS QUIDDITCH_TEST_DEPENDS)
     list(APPEND _LIT_PATH_ARGS "--path" "$<TARGET_FILE_DIR:${_TOOL}>")
 endforeach ()
 
+add_custom_target(quidditch-test-depends DEPENDS ${QUIDDITCH_TEST_DEPENDS})
+
 add_custom_target(check-quidditch
         COMMAND
         ${Python3_EXECUTABLE}
         ${QUIDDITCH_BIN_DIR}/quidditch-lit.py
         "${CMAKE_CURRENT_BINARY_DIR}"
         -v ${_LIT_PATH_ARGS}
-        DEPENDS ${QUIDDITCH_TEST_DEPENDS})
+    DEPENDS quidditch-test-depends)

--- a/runtime/snitch_cluster/CMakeLists.txt
+++ b/runtime/snitch_cluster/CMakeLists.txt
@@ -3,7 +3,7 @@ project(snRuntime C ASM)
 # Required for running regtool and clustergen.
 find_package(Python3 REQUIRED)
 # Required for finding regtool.
-find_program(bender_path NAMES bender REQUIRED)
+find_program(BENDER_PATH NAMES bender REQUIRED)
 
 set(SNITCH_RUNTIME_TARGET "rtl" CACHE STRING "Snitch runtime target to use")
 
@@ -14,10 +14,11 @@ set(runtime_dir ${CMAKE_CURRENT_LIST_DIR}/${SNITCH_RUNTIME_TARGET})
 
 # Get the path of regtool from bender. This will additionally automatically
 # install it.
-execute_process(COMMAND ${bender_path} path register_interface
+execute_process(COMMAND ${BENDER_PATH} path register_interface
     OUTPUT_VARIABLE reggen_base_path
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    WORKING_DIRECTORY ${snRuntimeSrc})
+    WORKING_DIRECTORY ${snRuntimeSrc}
+    COMMAND_ERROR_IS_FATAL ANY)
 set(reggen_path ${reggen_base_path}/vendor/lowrisc_opentitan/util/regtool.py)
 
 # Generate the 'snitch_cluster_peripheral.h' header.


### PR DESCRIPTION
The megabuild is a single top-level cmake file performing most of the required steps to build and test the entire project. Not only does this simplify CI but also serves as a good getting started point for pure users