### PR TITLE
[toolchain] Optimize for speed rather than size

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Quidditch Toolchain
         run: |
           mkdir ./toolchain
-          docker run --rm ghcr.io/opencompl/quidditch/toolchain:optimize-speed-over-size tar -cC /opt/quidditch-toolchain . \
+          docker run --rm ghcr.io/opencompl/quidditch/toolchain:main tar -cC /opt/quidditch-toolchain . \
           | tar -xC ./toolchain
 
       - name: Configure Megabuild

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Quidditch Toolchain
         run: |
           mkdir ./toolchain
-          docker run --rm ghcr.io/opencompl/quidditch/toolchain:main tar -cC /opt/quidditch-toolchain . \
+          docker run --rm ghcr.io/opencompl/quidditch/toolchain:optimize-speed-over-size tar -cC /opt/quidditch-toolchain . \
           | tar -xC ./toolchain
 
       - name: Configure Megabuild

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.21)
 
 project(QuidditchRuntime LANGUAGES C ASM)
 
+set(CMAKE_C_STANDARD 11)
+
 set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE STRING "IREE source code path")
 set(SNITCH_CLUSTER_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../snitch_cluster" CACHE STRING "snitch_cluster source code path")
 set(QUIDDITCH_CODEGEN_BUILD_DIR "" CACHE STRING "CMake generation directory with a compiled 'iree-compile'")
@@ -14,6 +16,7 @@ add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions> $<$<COMPILE_LANGU
 
 # Configuration for our target that must be present in all code using IREE.
 add_definitions(-DIREE_PLATFORM_GENERIC)
+add_definitions(-D_ISOC11_SOURCE)
 add_definitions(-DIREE_USER_CONFIG_H="${CMAKE_CURRENT_LIST_DIR}/iree-configuration/config.h")
 add_subdirectory(iree-configuration)
 

--- a/runtime/toolchain/Dockerfile
+++ b/runtime/toolchain/Dockerfile
@@ -54,6 +54,8 @@ RUN mkdir picolibc/build && cd picolibc/build &&  \
     -Dincludedir=include \
     -Dlibdir=lib  \
     --cross-file /cross.txt  \
+    --buildtype=release  \
+    -Dnewlib-nano-malloc=false \
     -Dpicocrt=false  \
     -Dpicolib=false  \
     -Dposix-console=true  \


### PR DESCRIPTION
None of our development setups have any size constraints on code as they're currently all in DRAM.

A faster executable greatly reduces time spent in simulation however, making this a worthwhile optimization for development.

This reduced verilator runtime by almost 3x on my local machine.