### PR TITLE
[runtime] Increase stack size for the LLVM backend

### DIFF
--- a/runtime/runtime/src/Quidditch/command_buffer/CMakeLists.txt
+++ b/runtime/runtime/src/Quidditch/command_buffer/CMakeLists.txt
@@ -7,7 +7,6 @@ iree_cc_library(
     SRCS
     "command_buffer.c"
     DEPS
-    snRuntime
     iree::base
     iree::base::internal
     iree::base::internal::cpu

--- a/runtime/runtime/src/Quidditch/device/CMakeLists.txt
+++ b/runtime/runtime/src/Quidditch/device/CMakeLists.txt
@@ -8,7 +8,6 @@ iree_cc_library(
     event.c
     semaphore.c
     DEPS
-    snRuntime
     iree::base
     iree::base::internal
     iree::base::internal::arena

--- a/runtime/runtime/src/Quidditch/dispatch/CMakeLists.txt
+++ b/runtime/runtime/src/Quidditch/dispatch/CMakeLists.txt
@@ -5,7 +5,7 @@ iree_cc_library(
     SRCS
     dispatch.c
     DEPS
-    snRuntime
+    snRuntimeInterface
     iree::base
     PUBLIC
 )

--- a/runtime/runtime/src/Quidditch/dispatch/dispatch.c
+++ b/runtime/runtime/src/Quidditch/dispatch/dispatch.c
@@ -3,8 +3,8 @@
 
 #include <assert.h>
 #include <cluster_interrupt_decls.h>
-#include <riscv.h>
-#include <snitch_cluster_defs.h>
+#include <encoding.h>
+#include <riscv_decls.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -46,8 +46,8 @@ void quidditch_dispatch_wait_for_workers() {
 static iree_hal_executable_dispatch_v0_t configuredKernel;
 static const iree_hal_executable_environment_v0_t* configuredEnvironment;
 static const iree_hal_executable_dispatch_state_v0_t* configuredDispatchState;
-static iree_alignas(64) iree_hal_executable_workgroup_state_v0_t
-    configuredWorkgroupState[SNRT_CLUSTER_CORE_NUM - 1];
+static iree_alignas(64)
+    iree_hal_executable_workgroup_state_v0_t configuredWorkgroupState[8];
 static atomic_bool error = false;
 
 bool quidditch_dispatch_errors_occurred() { return error; }

--- a/runtime/runtime/src/Quidditch/executable/CMakeLists.txt
+++ b/runtime/runtime/src/Quidditch/executable/CMakeLists.txt
@@ -7,7 +7,7 @@ iree_cc_library(
     SRCS
     "executable.c"
     DEPS
-    snRuntime
+    snRuntimeInterface
     Quidditch::dispatch::dispatch
     iree::base
     iree::hal::local::executable_library

--- a/runtime/runtime/src/Quidditch/loader/CMakeLists.txt
+++ b/runtime/runtime/src/Quidditch/loader/CMakeLists.txt
@@ -5,7 +5,6 @@ iree_cc_library(
     SRCS
     loader.c
     DEPS
-    snRuntime
     iree::base
     Quidditch::executable::executable
     PUBLIC

--- a/runtime/samples/util/CMakeLists.txt
+++ b/runtime/samples/util/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_libraries(
     iree::base
     iree::vm
     PRIVATE
-    snRuntime
+    snRuntimeInterface
     iree::modules::hal
     iree::modules::hal::types
     iree::hal::local::local

--- a/runtime/samples/util/run_model.c
+++ b/runtime/samples/util/run_model.c
@@ -10,7 +10,7 @@
 #include <iree/modules/hal/types.h>
 #include <iree/vm/instance.h>
 
-#include <snitch_cluster_defs.h>
+#include <stack_decls.h>
 #include <team_decls.h>
 
 iree_allocator_t l1_allocator() {
@@ -21,7 +21,7 @@ iree_allocator_t l1_allocator() {
 
   l1_arena.buffer = (uint8_t*)snrt_l1_start_addr();
   l1_arena.length = 0;
-  unsigned stack_size_per_core = 1 << SNRT_LOG2_STACK_SIZE;
+  unsigned stack_size_per_core = snrt_get_stack_size_per_core();
   l1_arena.capacity =
       (snrt_l1_end_addr() - snrt_cluster_core_num() * stack_size_per_core) -
       snrt_l1_start_addr();

--- a/runtime/snitch_cluster/CMakeLists.txt
+++ b/runtime/snitch_cluster/CMakeLists.txt
@@ -5,12 +5,9 @@ find_package(Python3 REQUIRED)
 # Required for finding regtool.
 find_program(BENDER_PATH NAMES bender REQUIRED)
 
-set(SNITCH_RUNTIME_TARGET "rtl" CACHE STRING "Snitch runtime target to use")
-
 set(snRuntimeSrc ${SNITCH_CLUSTER_SOURCE_DIR})
 set(header_dir ${CMAKE_CURRENT_BINARY_DIR}/cluster_gen)
 set(config_file ${snRuntimeSrc}/target/snitch_cluster/cfg/default.hjson)
-set(runtime_dir ${CMAKE_CURRENT_LIST_DIR}/${SNITCH_RUNTIME_TARGET})
 
 # Get the path of regtool from bender. This will additionally automatically
 # install it.
@@ -49,25 +46,40 @@ endmacro()
 run_cluster_gen(${snRuntimeSrc}/target/snitch_cluster/sw/runtime/common/snitch_cluster_addrmap.h.tpl)
 run_cluster_gen(${snRuntimeSrc}/target/snitch_cluster/sw/runtime/common/snitch_cluster_cfg.h.tpl)
 
+add_custom_target(snRuntimeConfig)
+add_dependencies(snRuntimeConfig cluster_gen snitch_cluster_peripheral.h)
 
-add_library(snRuntime
-    ${runtime_dir}/src/snitch_cluster_start.S
-    ${runtime_dir}/src/snrt.c
-    ${runtime_dir}/src/syscalls.c
+# Interface abstraction into the snitch runtime that any library user should be
+# using. It is guaranteed not to leak any hardware details.
+add_library(snRuntimeInterface INTERFACE)
+target_include_directories(snRuntimeInterface
+    INTERFACE
+    ${snRuntimeSrc}/sw/snRuntime/api
+    ${snRuntimeSrc}/sw/deps/riscv-opcodes
+    ${CMAKE_CURRENT_LIST_DIR}/api
 )
+# Required while snRuntime uses 'inline' qualifiers for declarations.
+target_compile_options(snRuntimeInterface INTERFACE -Wno-undefined-inline)
+
+# Default implementation of the snitch runtime that executables should link
+# against.
+add_library(snRuntime
+    rtl/src/snitch_cluster_start.S
+    rtl/src/snrt.c
+    rtl/src/syscalls.c
+)
+target_link_libraries(snRuntime PUBLIC snRuntimeInterface)
 target_include_directories(snRuntime
-    PUBLIC
+    PRIVATE
     ${snRuntimeSrc}/sw/snRuntime/src
     ${header_dir}
     ${snRuntimeSrc}/target/snitch_cluster/sw/runtime/common/
-    ${snRuntimeSrc}/sw/snRuntime/api
 )
-add_dependencies(snRuntime cluster_gen snitch_cluster_peripheral.h)
+add_dependencies(snRuntime snRuntimeConfig)
 target_link_options(snRuntime INTERFACE -Tbase.ld)
 target_link_directories(snRuntime
     INTERFACE
+    # For linker scripts.
     ${snRuntimeSrc}/sw/snRuntime
-    ${runtime_dir}
+    rtl
 )
-# Required while snRuntime uses 'inline' qualifiers for declarations.
-target_compile_options(snRuntime PRIVATE -Wno-undefined-inline)

--- a/runtime/snitch_cluster/api/stack_decls.h
+++ b/runtime/snitch_cluster/api/stack_decls.h
@@ -1,0 +1,6 @@
+
+#pragma once
+
+#include <stdint.h>
+
+uint32_t snrt_get_stack_size_per_core(void);

--- a/runtime/snitch_cluster/rtl/src/quidditch_cluster_defs.h
+++ b/runtime/snitch_cluster/rtl/src/quidditch_cluster_defs.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "snitch_cluster_addrmap.h"
+#include "snitch_cluster_cfg.h"
+#include "snitch_cluster_peripheral.h"
+
+// Hardware parameters
+#define SNRT_BASE_HARTID CFG_CLUSTER_BASE_HARTID
+#define SNRT_CLUSTER_CORE_NUM CFG_CLUSTER_NR_CORES
+#define SNRT_CLUSTER_NUM 1
+#define SNRT_CLUSTER_DM_CORE_NUM 1
+#define SNRT_TCDM_START_ADDR CLUSTER_TCDM_BASE_ADDR
+#define SNRT_TCDM_SIZE (CLUSTER_PERIPH_BASE_ADDR - CLUSTER_TCDM_BASE_ADDR)
+#define SNRT_CLUSTER_OFFSET 0x40000
+#define SNRT_CLUSTER_HW_BARRIER_ADDR \
+  (CLUSTER_PERIPH_BASE_ADDR + SNITCH_CLUSTER_PERIPHERAL_HW_BARRIER_REG_OFFSET)
+
+// Software configuration
+#define SNRT_LOG2_STACK_SIZE 11

--- a/runtime/snitch_cluster/rtl/src/snitch_cluster_start.S
+++ b/runtime/snitch_cluster/rtl/src/snitch_cluster_start.S
@@ -10,5 +10,5 @@
 #define SNRT_INIT_TLS
 #define SNRT_CRT0_PARK
 
-#include "snitch_cluster_defs.h"
+#include "quidditch_cluster_defs.h"
 #include "start.S"

--- a/runtime/snitch_cluster/rtl/src/snrt.c
+++ b/runtime/snitch_cluster/rtl/src/snrt.c
@@ -10,5 +10,8 @@
 #include "riscv.c"
 #include "snitch_cluster_memory.c"
 #include "snitch_cluster_start.c"
+#include "stack_decls.h"
 #include "sync.c"
 #include "team.c"
+
+uint32_t snrt_get_stack_size_per_core() { return 1 << SNRT_LOG2_STACK_SIZE; }

--- a/runtime/snitch_cluster/rtl/src/snrt.h
+++ b/runtime/snitch_cluster/rtl/src/snrt.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 // Snitch cluster specific
-#include "snitch_cluster_defs.h"
+#include "quidditch_cluster_defs.h"
 #include "snitch_cluster_memory.h"
 
 // Forward declarations


### PR DESCRIPTION
The LLVM backend and IREE host-code use a non-trivial amount of stack space. Measurements on NsNet2 showed both to need around 10kb of stack space per core. This PR therefore increases the stack size from the previous 8kB to 16kB.

Note that the stack memory is placed into L1 memory. Whether this makes any sense and whether to spend more time on reducing stack space to have more L1 memory for buffers remains to be seen.