### PR TITLE
[cmake] use `PATH` and `FILEPATH` cache variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 project(Quidditch C CXX)
 
-set(QUIDDITCH_TOOLCHAIN_FILE "" CACHE STRING "Path to the quidditch toolchain's toolchain file")
+set(QUIDDITCH_TOOLCHAIN_FILE "" CACHE FILEPATH "Path to the quidditch toolchain's toolchain file")
 set(OVERRIDE_VENV OFF CACHE BOOL "")
 cmake_path(REMOVE_FILENAME QUIDDITCH_TOOLCHAIN_FILE OUTPUT_VARIABLE QUIDDITCH_TOOLCHAIN_ROOT)
 

--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.21)
 project(QuidditchCompiler LANGUAGES CXX C)
 
-set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE STRING "IREE source code path")
-set(QUIDDITCH_TOOLCHAIN_ROOT "" CACHE STRING "Path to the Quidditch toolchain")
+set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE PATH "IREE source code path")
+set(QUIDDITCH_TOOLCHAIN_ROOT "" CACHE PATH "Path to the Quidditch toolchain")
 
 add_subdirectory(iree-configuration)
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -4,9 +4,9 @@ project(QuidditchRuntime LANGUAGES C ASM)
 
 set(CMAKE_C_STANDARD 11)
 
-set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE STRING "IREE source code path")
-set(SNITCH_CLUSTER_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../snitch_cluster" CACHE STRING "snitch_cluster source code path")
-set(QUIDDITCH_CODEGEN_BUILD_DIR "" CACHE STRING "CMake generation directory with a compiled 'iree-compile'")
+set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE PATH "IREE source code path")
+set(SNITCH_CLUSTER_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../snitch_cluster" CACHE PATH "snitch_cluster source code path")
+set(QUIDDITCH_CODEGEN_BUILD_DIR "" CACHE PATH "CMake generation directory with a compiled 'iree-compile'")
 
 list(APPEND CMAKE_MODULE_PATH
         ${CMAKE_CURRENT_LIST_DIR}/cmake/


### PR DESCRIPTION
Using these automatically makes `cmake` convert paths given on the command line via `-D` from relative to absolute paths.