### PR TITLE
[cmake] add script for automatic performance evaluation after runs

### DIFF
--- a/runtime/requirements.txt
+++ b/runtime/requirements.txt
@@ -4,3 +4,5 @@ mako==1.3.*
 jsonschema==4.21.*
 tabulate==0.9.*
 PyYAML==6.0.*
+pandas==2.2.2
+progressbar2==4.4.2

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(CTest)
 
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
 # Sanity check that our toolchain, emulator etc. work
 add_executable(HelloWorld main.c)
 target_link_libraries(HelloWorld snRuntime)

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -57,4 +57,4 @@ endmacro()
 
 test_executable(HelloWorld)
 test_executable(vec_multiply)
-test_executable(NsNet2LLVM)
+# test_executable(NsNet2LLVM)

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -6,8 +6,53 @@ target_link_libraries(HelloWorld snRuntime)
 
 macro(test_executable target_name)
   file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test)
-  add_test(NAME ${target_name} COMMAND ${target_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test)
+  add_test(NAME ${target_name}
+      COMMAND ${target_name}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test)
+  set_tests_properties(${target_name} PROPERTIES FIXTURES_REQUIRED ${target_name}-fixture)
+
+  add_test(NAME ${target_name}-setup
+      COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test/*
+  )
+  set_tests_properties(${target_name}-setup PROPERTIES FIXTURES_SETUP ${target_name}-fixture)
+
+  set(gen_traces_targets)
+  set(gen_traces_jsons)
+  set(gen_traces_raw)
+  foreach (i RANGE 0 8)
+    add_test(NAME ${target_name}-analysis-hart-${i}
+        COMMAND
+        sh -c "\
+        cat ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test/logs/trace_hart_0000000${i}.dasm \
+        | ${QUIDDITCH_TOOLCHAIN_ROOT}/bin/spike-dasm > \
+        ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test/logs/trace_hart_0000000${i}.asm \
+        && ${Python3_EXECUTABLE} ${SNITCH_CLUSTER_SOURCE_DIR}/util/trace/gen_trace.py \
+        ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test/logs/trace_hart_0000000${i}.asm \
+        -d hart_${i}_perf.json > metrics_hart_${i}.txt"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test
+    )
+    set_tests_properties(${target_name}-analysis-hart-${i} PROPERTIES
+        FIXTURES_CLEANUP ${target_name}-fixture
+    )
+    list(APPEND gen_traces_targets "${target_name}-analysis-hart-${i}")
+    list(APPEND gen_traces_jsons "${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test/hart_${i}_perf.json")
+    list(APPEND gen_traces_raw "${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test/logs/trace_hart_0000000${i}.asm")
+  endforeach ()
+
+  add_test(NAME ${target_name}-events.json
+      COMMAND
+      ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/util/snitch_trace_to_perfetto.py
+      -i ${gen_traces_jsons} --traces ${gen_traces_raw} --elf $<TARGET_FILE:${target_name}>
+      -o events.json
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${target_name}.test
+      COMMAND_EXPAND_LISTS
+  )
+  set_tests_properties(${target_name}-events.json PROPERTIES
+      FIXTURES_CLEANUP ${target_name}-fixture
+      DEPENDS "${gen_traces_targets}"
+  )
 endmacro()
 
 test_executable(HelloWorld)
 test_executable(vec_multiply)
+test_executable(NsNet2LLVM)

--- a/runtime/util/snitch_trace_to_perfetto.py
+++ b/runtime/util/snitch_trace_to_perfetto.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+
+
+def main():
+    # Argument parsing
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-i',
+        '--inputs',
+        metavar='<inputs>',
+        nargs='+',
+        help='Input performance metric dumps')
+    parser.add_argument(
+        '--traces',
+        metavar='<trace>',
+        nargs='*',
+        help='Simulation traces to process')
+    parser.add_argument(
+        '--elf',
+        nargs='?',
+        help='ELF from which the traces were generated')
+    parser.add_argument(
+        '-o',
+        '--output',
+        metavar='<json>',
+        nargs='?',
+        default='events.json',
+        help='Output JSON file')
+    args = parser.parse_args()
+
+    # TraceViewer events
+    events = []
+    for hartid, file in enumerate(args.inputs):
+        with open(file, 'rb') as f:
+            j = json.load(f)
+            for index, section in enumerate(j):
+                if index % 2 == 0:
+                    continue
+
+                start = section['tstart'] / 1e3
+                dur = (section['tend'] - section['tstart']) / 1e3
+                events.append({
+                    # TODO: Get and demangle kernel name.
+                    'name': f'section {index}',
+                    'ts': start,
+                    'dur': dur,
+                    'ph': 'X',
+                    'cat': 'kernel',
+                    'pid': 0,
+                    'tid': hartid,
+                    'args': section,
+                })
+
+
+    # Create TraceViewer JSON object
+    tvobj = {}
+    tvobj['traceEvents'] = events
+    tvobj['displayTimeUnit'] = "ns"
+
+    # Dump TraceViewer events to JSON file
+    with open(args.output, 'w') as f:
+        json.dump(tvobj, f, indent=4)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
The script analyzes the traces of each RISC-V core using ETH's script to first denote sections and get performance data about each section. Afterwards, it creates a trace file suitable for https://ui.perfetto.dev/ to create a timeline view of the kernel execution.