### PR TITLE
[dispatch] Synchronize using barriers rather than local interrupts

### DIFF
--- a/runtime/runtime/src/Quidditch/dispatch/dispatch.h
+++ b/runtime/runtime/src/Quidditch/dispatch/dispatch.h
@@ -15,22 +15,23 @@ int quidditch_dispatch_enter_worker_loop(void);
 /// the work loop.
 void quidditch_dispatch_quit(void);
 
-/// Causes the host core to wait for all workers to enter a parked state again.
-void quidditch_dispatch_wait_for_workers(void);
-
 /// Returns true if any kernel execution of any compute core ever caused an
 /// error.
 bool quidditch_dispatch_errors_occurred();
 
 /// Configures the kernel, environment and dispatch state to use for subsequent
-/// 'quidditch_dispatch_submit_workgroup' calls. It is impossible for a cluster
+/// 'quidditch_dispatch_queue_workgroup' calls. It is impossible for a cluster
 /// to execute more than one kernel at a time.
 void quidditch_dispatch_set_kernel(
     iree_hal_executable_dispatch_v0_t kernel,
     const iree_hal_executable_environment_v0_t* environment,
     const iree_hal_executable_dispatch_state_v0_t* dispatch_state);
 
-/// Dispatches the compute core with the id 'workgroup_state->processorId' to
-/// execute the last configured kernel with the given workgroup state.
-void quidditch_dispatch_submit_workgroup(
+/// Queues a workgroup on a compute core with the last configured kernel and
+/// dispatch state. May block and execute if all cores have a workgroup
+/// assigned to them.
+void quidditch_dispatch_queue_workgroup(
     const iree_hal_executable_workgroup_state_v0_t* workgroup_state);
+
+/// Executes all queued workgroups and waits for them to finish.
+void quidditch_dispatch_execute_workgroups();


### PR DESCRIPTION
The `wfi` instruction, technically speaking, is not guaranteed to halt the core nor be woken up by exactly the interrupt we want. Hardware barriers are the more canonical way of implementing synchronization within a cluster and our new implementation also parks the DMA core during kernel execution instead of making it busy loop. This is mainly useful for simulation time and power usage in real code.