### PR TITLE
[runtime] trace DMA/VM core time as well

### DIFF
--- a/runtime/runtime/src/Quidditch/executable/executable.c
+++ b/runtime/runtime/src/Quidditch/executable/executable.c
@@ -180,6 +180,7 @@ iree_status_t quidditch_executable_issue_dispatch_inline(
   quidditch_dispatch_set_kernel(kernel, &executable->environment,
                                 dispatch_state);
 
+  read_csr(mcycle);
   for (uint32_t z = 0; z < workgroup_count_z; ++z) {
     workgroup_state.workgroup_id_z = z;
     for (uint32_t y = 0; y < workgroup_count_y; ++y) {
@@ -193,6 +194,7 @@ iree_status_t quidditch_executable_issue_dispatch_inline(
   }
 
   quidditch_dispatch_execute_workgroups();
+  read_csr(mcycle);
 
   if (quidditch_dispatch_errors_occurred())
     return iree_make_status(IREE_STATUS_INTERNAL);

--- a/runtime/util/snitch_trace_to_perfetto.py
+++ b/runtime/util/snitch_trace_to_perfetto.py
@@ -35,21 +35,29 @@ def main():
     # TraceViewer events
     events = []
     for hartid, file in enumerate(args.inputs):
+        is_dm_core = hartid == 8
+
         with open(file, 'rb') as f:
             j = json.load(f)
             for index, section in enumerate(j):
-                if index % 2 == 0:
-                    continue
+                # In the case of the DMA core we are interested in time spent between kernels to measure overhead of
+                # IREE abstractions.
+                if not is_dm_core:
+                    if index % 2 == 0:
+                        continue
+                else:
+                    if index % 2 == 1:
+                        continue
 
                 start = section['tstart'] / 1e3
                 dur = (section['tend'] - section['tstart']) / 1e3
                 events.append({
                     # TODO: Get and demangle kernel name.
-                    'name': f'section {index}',
+                    'name': f'{"vm" if is_dm_core else "kernel"} {index}',
                     'ts': start,
                     'dur': dur,
                     'ph': 'X',
-                    'cat': 'kernel',
+                    'cat': 'vm' if is_dm_core else 'kernel',
                     'pid': 0,
                     'tid': hartid,
                     'args': section,


### PR DESCRIPTION
This way we'll be able to measure time spent in between kernels within IREE machinery.