### PR TITLE
[compiler][HoistHALOps] Perform value replacement after hoisting

### DIFF
--- a/codegen/CMakeLists.txt
+++ b/codegen/CMakeLists.txt
@@ -5,6 +5,7 @@ set(IREE_SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../iree" CACHE PATH "IREE source 
 set(QUIDDITCH_TOOLCHAIN_ROOT "" CACHE PATH "Path to the Quidditch toolchain")
 
 add_subdirectory(iree-configuration)
+add_subdirectory(tools)
 
 enable_testing()
 include(CTest)

--- a/codegen/compiler/src/Quidditch/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/CMakeLists.txt
@@ -16,16 +16,27 @@ iree_tablegen_library(
 
 iree_cc_library(
         NAME
-        Quidditch
+        QuidditchPasses
         HDRS
         "Passes.h"
         "Passes.h.inc"
         SRCS
-        "QuidditchTarget.cpp"
         "HoistHALOpsToFunc.cpp"
         "FilterForxDSL.cpp"
         DEPS
         ::PassesIncGen
+        MLIRFuncDialect
+        MLIRIR
+        iree::compiler::Dialect::HAL::IR
+)
+
+iree_cc_library(
+        NAME
+        Quidditch
+        SRCS
+        "QuidditchTarget.cpp"
+        DEPS
+        ::QuidditchPasses
         IREELinalgTransformDialect
         LLVMAnalysis
         LLVMBitReader

--- a/codegen/tests/CMakeLists.txt
+++ b/codegen/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ find_program(XDSL_OPT_PATH xdsl-opt
 
 set(QUIDDITCH_TEST_DEPENDS
         FileCheck count not split-file
-        iree-compile
+        iree-compile quidditch-opt
 )
 
 set(QUIDDITCH_LIT_SITE_CFG_OUT ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py)

--- a/codegen/tests/HostHALOpsToFunc/test.mlir
+++ b/codegen/tests/HostHALOpsToFunc/test.mlir
@@ -1,0 +1,23 @@
+// RUN: quidditch-opt %s --quidditch-hoist-hal-ops-to-func | FileCheck %s
+
+// TODO: The first argument is dead/redundant after hoisting.
+
+// CHECK-LABEL: func @test(
+// CHECK-SAME: %[[ARG0:.*]]: i32
+// CHECK-SAME: %[[ARG1:.*]]: memref
+// CHECK-SAME: attributes
+// CHECK-SAME: llvm.bareptr
+// CHECK-SAME: xdsl_generated
+func.func @test() {
+  %0 = hal.interface.constant.load[0] : i32
+  // CHECK: arith.index_castui %[[ARG0]]
+  %1 = arith.index_castui %0 : i32 to index
+  %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%1) flags(ReadOnly) : memref<1x400xf64>
+  return
+}
+
+// CHECK-LABEL: func @test$iree_to_xdsl()
+// CHECK: %[[C:.*]] = hal.interface.constant.load[0] : i32
+// CHECK: %[[CAST:.*]] = arith.index_castui %[[C]] : i32 to index
+// CHECK: %[[MEMREF:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%[[CAST]]) flags(ReadOnly)
+// CHECK: call @test(%[[C]], %[[MEMREF]])

--- a/codegen/tools/CMakeLists.txt
+++ b/codegen/tools/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(quidditch-opt quidditch-opt.cpp)
+target_link_libraries(quidditch-opt
+        PRIVATE
+        MLIROptLib
+        Quidditch::QuidditchPasses
+        iree::compiler::Dialect::LinalgExt::IR
+        iree::compiler::Tools::init_passes_and_dialects
+)

--- a/codegen/tools/quidditch-opt.cpp
+++ b/codegen/tools/quidditch-opt.cpp
@@ -1,0 +1,23 @@
+#include <iree/compiler/Tools/init_dialects.h>
+#include <mlir/Tools/mlir-opt/MlirOptMain.h>
+
+#include <Quidditch/Passes.h>
+
+namespace quidditch {
+#define GEN_PASS_REGISTRATION
+#include "Quidditch/Passes.h.inc"
+} // namespace quidditch
+
+using namespace mlir;
+
+int main(int argc, char **argv) {
+
+  // Be lazy and support all upstream dialects as input dialects.
+  DialectRegistry registry;
+  iree_compiler::registerAllDialects(registry);
+
+  quidditch::registerPasses();
+
+  return mlir::asMainReturnCode(mlir::MlirOptMain(
+      argc, argv, "MLIR modular optimizer driver\n", registry));
+}


### PR DESCRIPTION
The hoisting process performs cloning of the operation and relies on all operands being cloned. If we perform the replacement prior to the cloning then the operands of operations that will be cloned are remapped too early and create an invalid use of an SSA value in another function.