### PR TITLE
[compiler][runtime] Compile modules with both LLVM and Quidditch

### DIFF
--- a/codegen/compiler/src/Quidditch/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/QuidditchTarget.cpp
@@ -272,7 +272,7 @@ public:
           IREE::HAL::LibraryBuilder::DispatchAttrs{localMemorySize}, llvmFunc);
     }
     auto *queryLibraryFunc =
-        libraryBuilder.build(libraryName + "_library_query");
+        libraryBuilder.build("quidditch_" + libraryName + "_library_query");
 
     // The query function must be exported for dynamic libraries.
     queryLibraryFunc->setDSOLocal(false);
@@ -393,7 +393,8 @@ public:
       return failure();
 
     if (!IREE::HAL::outputStaticLibrary(
-            libraryName, libraryName + "_library_query",
+            "quidditch_" + libraryName,
+            "quidditch_" + libraryName + "_library_query",
             targetOptions.staticLibraryOutputPath, linkedObject.path))
       return variantOp.emitError() << "static library generation failed";
 

--- a/runtime/samples/nsnet2/main.c
+++ b/runtime/samples/nsnet2/main.c
@@ -1,6 +1,6 @@
 #include <Quidditch/dispatch/dispatch.h>
 
-#include <nsnet2.h>
+#include <nsnet2_llvm.h>
 #include <nsnet2_module.h>
 #include <team_decls.h>
 #include <util/run_model.h>

--- a/runtime/samples/vec_multiply/main.c
+++ b/runtime/samples/vec_multiply/main.c
@@ -1,6 +1,7 @@
 #include <Quidditch/dispatch/dispatch.h>
 
 #include <simple_add.h>
+#include <simple_add_llvm.h>
 #include <simple_add_module.h>
 #include <team_decls.h>
 #include <util/run_model.h>
@@ -16,8 +17,10 @@ int main() {
   model_config_t config = {
       .libraries =
           (iree_hal_executable_library_query_fn_t[]){
-              add_dispatch_0_library_query},
-      .num_libraries = 1,
+              quidditch_add_dispatch_0_library_query,
+              add_dispatch_0_library_query,
+          },
+      .num_libraries = 2,
       .module_constructor = test_simple_add_create,
       .main_function = iree_make_cstring_view("test_simple_add.add"),
 


### PR DESCRIPTION
Having both Quidditch and LLVM output allows us to freely use kernels generated by either of the two, depending on the order they're registered in our loader.

The main use-case is for us to be able to gradually introduce xDSL output by falling back to LLVM when xDSL is incapable of compiling a kernel.