### PR TITLE
[compiler] Implement fallback compilation of Quidditch kernels with LLVM

### DIFF
--- a/codegen/compiler/src/Quidditch/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/CMakeLists.txt
@@ -22,9 +22,10 @@ iree_cc_library(
         "Passes.h.inc"
         SRCS
         "ConvertToRISCV.cpp"
+        "DisableQuidditchVariant.cpp"
         "FilterForxDSL.cpp"
         "HoistHALOpsToFunc.cpp"
-        "FilterForxDSL.cpp"
+        "LinkExecutables.cpp"
         DEPS
         ::PassesIncGen
         MLIRFuncDialect

--- a/codegen/compiler/src/Quidditch/ConvertToRISCV.cpp
+++ b/codegen/compiler/src/Quidditch/ConvertToRISCV.cpp
@@ -92,7 +92,6 @@ void ConvertToRISCV::runOnOperation() {
   // Function body no longer needed.
   func.getBody().getBlocks().clear();
   func.setVisibility(SymbolTable::Visibility::Private);
-  func->removeAttr("xdsl_generated");
   // Required to tell the conversion pass to LLVM that this is actually a
   // call into the same linkage unit and does not have to be rewritten to a
   // HAL module call.

--- a/codegen/compiler/src/Quidditch/DisableQuidditchVariant.cpp
+++ b/codegen/compiler/src/Quidditch/DisableQuidditchVariant.cpp
@@ -1,0 +1,45 @@
+#include "Passes.h"
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+namespace quidditch {
+#define GEN_PASS_DEF_DISABLEQUIDDITCHVARIANTPASS
+#include "Quidditch/Passes.h.inc"
+} // namespace quidditch
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+namespace {
+class DisableQuidditchVariant
+    : public quidditch::impl::DisableQuidditchVariantPassBase<
+          DisableQuidditchVariant> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+void DisableQuidditchVariant::runOnOperation() {
+  // The following code makes the assumption that it is run before linkage,
+  // meaning that one hal.executable.variant contains exactly one kernel.
+  IREE::HAL::ExecutableVariantOp operation = getOperation();
+  ModuleOp module = operation.getInnerModule();
+
+  // If xDSL failed to compile the kernel, then disable this variant
+  // permanently. While the code will later be replaced by the linker using
+  // LLVM code, the dispatch code needs to also be informed to make sure that
+  // the right workgroup sizes are used for the kernel.
+  for (auto func : module.getOps<LLVM::LLVMFuncOp>())
+    if (func->hasAttr("xdsl_generated") && func->hasAttr("riscv_assembly"))
+      return;
+
+  OpBuilder builder(&getContext());
+  operation.createConditionOp(builder);
+  Value falseC = builder.create<arith::ConstantOp>(operation->getLoc(),
+                                                   builder.getBoolAttr(false));
+  builder.create<IREE::HAL::ReturnOp>(operation->getLoc(), falseC);
+}

--- a/codegen/compiler/src/Quidditch/LinkExecutables.cpp
+++ b/codegen/compiler/src/Quidditch/LinkExecutables.cpp
@@ -1,0 +1,133 @@
+#include "Passes.h"
+
+#include "iree/compiler/Codegen/Utils/LinkingUtils.h"
+#include "iree/compiler/Utils/ModuleUtils.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+namespace quidditch {
+#define GEN_PASS_DEF_LINKEXECUTABLESPASS
+#include "Quidditch/Passes.h.inc"
+} // namespace quidditch
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+
+namespace {
+class LinkExecutables
+    : public quidditch::impl::LinkExecutablesPassBase<LinkExecutables> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+void LinkExecutables::runOnOperation() {
+  ModuleOp moduleOp = getOperation();
+  auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
+
+  auto sourceExecutableOps =
+      llvm::to_vector<8>(moduleOp.getOps<IREE::HAL::ExecutableOp>());
+  if (sourceExecutableOps.size() <= 1)
+    return;
+
+  // Guess a module name, if needed, to make the output files readable.
+  std::string moduleName = guessModuleName(moduleOp, "quidditch_module");
+
+  // Create our new "linked" hal.executable.
+  std::string linkedExecutableName =
+      llvm::formatv("{0}_linked_{1}", moduleName, "quidditch");
+  auto linkedExecutableOp = moduleBuilder.create<IREE::HAL::ExecutableOp>(
+      moduleOp.getLoc(), linkedExecutableName);
+  linkedExecutableOp.setVisibility(sourceExecutableOps.front().getVisibility());
+  auto executableBuilder =
+      OpBuilder::atBlockBegin(&linkedExecutableOp.getBlock());
+
+  IREE::HAL::ExecutableVariantOp llvmVariant;
+  IREE::HAL::ExecutableVariantOp quidditchVariant;
+
+  // Gather all unique executable targets - we may have multiple.
+  SetVector<IREE::HAL::ExecutableTargetAttr> executableTargetAttrs =
+      gatherExecutableTargets(sourceExecutableOps);
+  for (auto [index, attr] : llvm::enumerate(executableTargetAttrs)) {
+    // Add our hal.executable.variant with an empty module.
+    std::string linkedVariantName =
+        executableTargetAttrs.size() == 1
+            ? attr.getSymbolNameFragment()
+            : llvm::formatv("{0}_{1}", attr.getSymbolNameFragment(), index);
+    auto linkedTargetOp =
+        executableBuilder.create<IREE::HAL::ExecutableVariantOp>(
+            moduleOp.getLoc(), linkedVariantName, attr);
+    auto targetBuilder = OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
+    targetBuilder.create<mlir::ModuleOp>(moduleOp.getLoc());
+
+    if (attr.getBackend() == "llvm-cpu")
+      llvmVariant = linkedTargetOp;
+    else if (attr.getBackend() == "quidditch")
+      quidditchVariant = linkedTargetOp;
+
+    auto mergeModuleFn = [](mlir::ModuleOp sourceInnerModule,
+                            mlir::ModuleOp linkedInnerModule,
+                            DenseMap<StringRef, Operation *> &symbolMap) {
+      return mergeModuleInto(sourceInnerModule, linkedInnerModule, symbolMap);
+    };
+
+    // Try linking together all executables in moduleOp.
+    if (failed(linkExecutablesInto(moduleOp, sourceExecutableOps,
+                                   linkedExecutableOp, linkedTargetOp,
+                                   mergeModuleFn))) {
+      return signalPassFailure();
+    }
+  }
+
+  if (!quidditchVariant || !llvmVariant)
+    return;
+
+  std::size_t xDSLFunctionsReplaced = 0;
+  std::size_t xDSLFunctionsEncountered = 0;
+  // Replace quidditch functions that xDSL could not compile with LLVM
+  // implementations.
+  auto builder =
+      OpBuilder::atBlockEnd(quidditchVariant.getInnerModule().getBody());
+  SymbolTable quidditchTable(quidditchVariant.getInnerModule());
+  SymbolTable llvmTable(llvmVariant.getInnerModule());
+  for (auto func : llvm::to_vector(
+           quidditchVariant.getInnerModule().getOps<LLVM::LLVMFuncOp>())) {
+    StringRef symName = func.getSymName();
+    if (!symName.consume_back("$iree_to_xdsl"))
+      continue;
+
+    xDSLFunctionsEncountered++;
+
+    // xDSL function is considered having failed to compile if it does not exist
+    // or does not have a body yet no 'riscv_assembly' either.
+    auto xdslFuncOp = quidditchTable.lookup<LLVM::LLVMFuncOp>(symName);
+    if (xdslFuncOp && xdslFuncOp->hasAttrOfType<StringAttr>("riscv_assembly"))
+      continue;
+
+    if (xdslFuncOp && !xdslFuncOp.empty())
+      continue;
+
+    auto llvmFuncOp =
+        llvmTable.lookup<LLVM::LLVMFuncOp>(xdslFuncOp.getSymNameAttr());
+    if (!llvmFuncOp)
+      continue;
+
+    if (xdslFuncOp)
+      xdslFuncOp.erase();
+
+    xDSLFunctionsReplaced++;
+
+    func.erase();
+    LLVM::LLVMFuncOp clone = llvmFuncOp.clone();
+    builder.insert(clone);
+  }
+
+  if (xDSLFunctionsReplaced)
+    emitWarning(moduleOp.getLoc(), "Replaced ")
+        << xDSLFunctionsReplaced << " out of " << xDSLFunctionsEncountered
+        << " kernels with LLVM implementations as they failed to compile";
+}

--- a/codegen/compiler/src/Quidditch/Passes.td
+++ b/codegen/compiler/src/Quidditch/Passes.td
@@ -3,6 +3,12 @@
 
 include "mlir/Pass/PassBase.td"
 
+defvar assertCompiledOption =
+  Option<"assertCompiled", "assert-compiled", "bool", "false",
+         "If true, errors if any kernel could not be compiled with xDSL."
+         "Otherwise, removes the kernel from the output and emits a warning "
+         "instead.">;
+
 def HoistHALOpsToFuncPass
   : Pass<"quidditch-hoist-hal-ops-to-func", "mlir::ModuleOp"> {
   let description = [{
@@ -16,6 +22,8 @@ def HoistHALOpsToFuncPass
 
     The original function is additionally tagged with a "xdsl_generated" unit attribute.
   }];
+
+  let options = [assertCompiledOption];
 }
 
 def FilterForxDSLPass
@@ -32,11 +40,27 @@ def ConvertToRISCVPass : Pass<"quidditch-convert-to-riscv", "mlir::func::FuncOp"
   let options = [
     Option<"xDSLOptPath", "xdsl-opt-path", "std::string", [{""}],
       "Path to the 'xdsl-opt' executable to use for kernel compilation.">,
-    Option<"assertCompiled", "assert-compiled", "bool", "false",
-      "If true, errors if any kernel could not be compiled with xDSL."
-      "Otherwise, removes the kernel from the output and emits a warning "
-      "instead.">,
+    assertCompiledOption,
   ];
+}
+
+def LinkExecutablesPass : Pass<"quidditch-link-executables", "mlir::ModuleOp"> {
+  let description = [{
+    Combines all `hal.executable.variant`s of the same target into a single
+    `hal.executable.variant` nested within one `hal.executable`.
+
+    Additionally performs replacement of any kernels that xDSL failed to
+    compile with LLVM implementations.
+  }];
+}
+
+def DisableQuidditchVariantPass : Pass<"quidditch-disable-variant",
+  "mlir::iree_compiler::IREE::HAL::ExecutableVariantOp"> {
+  let description = [{
+    Disables the `hal.executable.variant` for Quidditch if `xDSL` failed
+    compilation. This is done by adding a `hal.executable.condition` returning
+    false.
+  }];
 }
 
 #endif

--- a/runtime/samples/nsnet2/CMakeLists.txt
+++ b/runtime/samples/nsnet2/CMakeLists.txt
@@ -1,6 +1,6 @@
 
-iree_turbine(SRC NsNet2.py DST ${CMAKE_CURRENT_BINARY_DIR}/nsnet2.mlirbc DTYPE "f32")
-quidditch_module(SRC ${CMAKE_CURRENT_BINARY_DIR}/nsnet2.mlirbc LLVM)
+iree_turbine(SRC NsNet2.py DST ${CMAKE_CURRENT_BINARY_DIR}/nsnet2.mlirbc DTYPE "f64")
+quidditch_module(SRC ${CMAKE_CURRENT_BINARY_DIR}/nsnet2.mlirbc)
 
 add_executable(NsNet2LLVM main.c)
 target_link_libraries(

--- a/runtime/samples/nsnet2/main.c
+++ b/runtime/samples/nsnet2/main.c
@@ -1,6 +1,6 @@
 #include <Quidditch/dispatch/dispatch.h>
 
-#include <nsnet2_llvm.h>
+#include <nsnet2.h>
 #include <nsnet2_module.h>
 #include <team_decls.h>
 #include <util/run_model.h>
@@ -8,7 +8,7 @@
 int main() {
   if (!snrt_is_dm_core()) return quidditch_dispatch_enter_worker_loop();
 
-  float data[161];
+  double data[161];
 
   for (int i = 0; i < IREE_ARRAYSIZE(data); i++) {
     data[i] = (i + 1);
@@ -17,12 +17,12 @@ int main() {
   model_config_t config = {
       .libraries =
           (iree_hal_executable_library_query_fn_t[]){
-              compiled_ns_net2_linked_llvm_cpu_library_query},
+              quidditch_compiled_ns_net2_linked_quidditch_library_query},
       .num_libraries = 1,
       .module_constructor = compiled_ns_net2_create,
       .main_function = iree_make_cstring_view("compiled_ns_net2.main"),
 
-      .element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      .element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_64,
 
       .num_inputs = 1,
       .input_data = (const void*[]){data, data},
@@ -41,7 +41,7 @@ int main() {
   if (!snrt_is_dm_core()) return 0;
 
   for (int i = 0; i < IREE_ARRAYSIZE(data); i++) {
-    float value = data[i];
+    double value = data[i];
     printf("%f\n", value);
   }
   return 0;

--- a/runtime/samples/vec_multiply/CMakeLists.txt
+++ b/runtime/samples/vec_multiply/CMakeLists.txt
@@ -1,4 +1,4 @@
-quidditch_module(SRC simple_add.mlir)
+quidditch_module(SRC simple_add.mlir ASSERT_XDSL)
 
 add_executable(vec_multiply main.c)
 target_link_libraries(

--- a/runtime/samples/vec_multiply/main.c
+++ b/runtime/samples/vec_multiply/main.c
@@ -1,7 +1,6 @@
 #include <Quidditch/dispatch/dispatch.h>
 
 #include <simple_add.h>
-#include <simple_add_llvm.h>
 #include <simple_add_module.h>
 #include <team_decls.h>
 #include <util/run_model.h>
@@ -18,9 +17,8 @@ int main() {
       .libraries =
           (iree_hal_executable_library_query_fn_t[]){
               quidditch_add_dispatch_0_library_query,
-              add_dispatch_0_library_query,
           },
-      .num_libraries = 2,
+      .num_libraries = 1,
       .module_constructor = test_simple_add_create,
       .main_function = iree_make_cstring_view("test_simple_add.add"),
 


### PR DESCRIPTION
The following things happen after this PR if a kernel fails to compile with xDSL:
* The code is replaced with the same kernel compiled with LLVM
* A warning is emitted with the `stderr` output of `xdsl-opt`
* The dispatch code for Quidditch is disabled. This is required to make sure that we use the right workgroup sizes

The positive of this change is that we can now gradually introduce and fix xDSL kernels one-at-a-time for whichever NNs we are interested in.