### PR TITLE
[compiler] Add pattern to raise ReLUs in select to `arith.maximumf` form

### DIFF
--- a/codegen/compiler/src/Quidditch/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
         "DisableQuidditchVariant.cpp"
         "OutlineLinalgOpsToxDSL.cpp"
         "LinkExecutables.cpp"
+        "ReluToMax.cpp"
         DEPS
         ::PassesIncGen
         MLIRFuncDialect

--- a/codegen/compiler/src/Quidditch/LinkExecutables.cpp
+++ b/codegen/compiler/src/Quidditch/LinkExecutables.cpp
@@ -34,6 +34,18 @@ void LinkExecutables::runOnOperation() {
   if (sourceExecutableOps.size() <= 1)
     return;
 
+  // TODO: This is a huge hack to workaround the linking process wanting a
+  //  unified condition for the resulting `hal.executable.variant`. We instead
+  //  want a condition per-kernel, aka per `hal.executable.variant` prior to
+  //  linking. We currently achieve this by using different
+  //  `hal.executable.condition` ops which are processed prior to linking in the
+  //  stream-to-hal conversion. Remove the condition now to satisfy the linker
+  //  requirement.
+  for (IREE::HAL::ExecutableOp executable : sourceExecutableOps)
+    for (auto variant : executable.getOps<IREE::HAL::ExecutableVariantOp>())
+      if (IREE::HAL::ExecutableConditionOp condition = variant.getConditionOp())
+        condition.erase();
+
   // Guess a module name, if needed, to make the output files readable.
   std::string moduleName = guessModuleName(moduleOp, "quidditch_module");
 

--- a/codegen/compiler/src/Quidditch/Passes.td
+++ b/codegen/compiler/src/Quidditch/Passes.td
@@ -51,4 +51,6 @@ def DisableQuidditchVariantPass : Pass<"quidditch-disable-variant",
   }];
 }
 
+def ReluToMaxPass : Pass<"quidditch-relu-to-max">;
+
 #endif

--- a/codegen/compiler/src/Quidditch/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/QuidditchTarget.cpp
@@ -155,6 +155,7 @@ public:
     modulePassManager.addPass(quidditch::createOutlineLinalgOpsToxDSLPass(
         {targetOptions.assertCompiled}));
     FunctionLikeNest(modulePassManager)
+        .addPass(quidditch::createReluToMaxPass)
         .addPass(createCanonicalizerPass)
         .addPass([&] {
           return quidditch::createConvertToRISCVPass(

--- a/codegen/compiler/src/Quidditch/ReluToMax.cpp
+++ b/codegen/compiler/src/Quidditch/ReluToMax.cpp
@@ -1,0 +1,77 @@
+#include "Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace quidditch {
+#define GEN_PASS_DEF_RELUTOMAXPASS
+#include "Quidditch/Passes.h.inc"
+} // namespace quidditch
+
+using namespace mlir;
+
+namespace {
+class ReluToMax : public quidditch::impl::ReluToMaxPassBase<ReluToMax> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+
+// Apparently arith.cmpf do not have a canonical representation for either LT
+// or GT.
+
+struct ReluSelectToMaxLTPattern : OpRewritePattern<arith::SelectOp> {
+
+  using OpRewritePattern<arith::SelectOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp op,
+                                PatternRewriter &rewriter) const override {
+    auto cmpFOp = op.getCondition().getDefiningOp<arith::CmpFOp>();
+    if (!cmpFOp)
+      return failure();
+    if (cmpFOp.getPredicate() != arith::CmpFPredicate::ULT)
+      return failure();
+    if (cmpFOp.getRhs() != op.getTrueValue())
+      return failure();
+    if (cmpFOp.getLhs() != op.getFalseValue())
+      return failure();
+
+    rewriter.replaceOpWithNewOp<arith::MaximumFOp>(op, cmpFOp.getLhs(),
+                                                   cmpFOp.getRhs());
+    return success();
+  }
+};
+
+struct ReluSelectToMaxGTPattern : OpRewritePattern<arith::SelectOp> {
+
+  using OpRewritePattern<arith::SelectOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(arith::SelectOp op,
+                                PatternRewriter &rewriter) const override {
+    auto cmpFOp = op.getCondition().getDefiningOp<arith::CmpFOp>();
+    if (!cmpFOp)
+      return failure();
+    if (cmpFOp.getPredicate() != arith::CmpFPredicate::UGT)
+      return failure();
+    if (cmpFOp.getRhs() != op.getFalseValue())
+      return failure();
+    if (cmpFOp.getLhs() != op.getTrueValue())
+      return failure();
+
+    rewriter.replaceOpWithNewOp<arith::MaximumFOp>(op, cmpFOp.getLhs(),
+                                                   cmpFOp.getRhs());
+    return success();
+  }
+};
+
+} // namespace
+
+void ReluToMax::runOnOperation() {
+  RewritePatternSet patterns(&getContext());
+  patterns.insert<ReluSelectToMaxLTPattern, ReluSelectToMaxGTPattern>(
+      &getContext());
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    signalPassFailure();
+}


### PR DESCRIPTION
The latter xDSL is capable of lowering to floating point instructions that can be placed inside a `frep` and is therefore a lot faster.

As a side-effect two more kernels in NsNet2 can be compiled which showed an issue with `hal.executable.condition` in the linker that had to be fixed as well.