### PR TITLE
[quidditch_snitch] Implement bufferization for microkernels

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.cpp
@@ -1,14 +1,177 @@
 #include "QuidditchSnitchOps.h"
 
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/IR/TypeUtilities.h"
 
 #define GET_OP_CLASSES
 #include "Quidditch/Dialect/Snitch/QuidditchSnitchOps.cpp.inc"
 
 using namespace mlir;
+using namespace mlir::bufferization;
 using namespace quidditch::Snitch;
 
-Block *XDSLKernelOp::createEntryBlock() {
+//===----------------------------------------------------------------------===//
+// TensorMicrokernelOp::RegionBranchOpInterface
+//===----------------------------------------------------------------------===//
+
+void TensorMicrokernelOp::getSuccessorRegions(
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  if (point.isParent()) {
+    regions.emplace_back(&getBody());
+    return;
+  }
+  regions.emplace_back(getResults());
+}
+
+void TensorMicrokernelOp::getRegionInvocationBounds(
+    ArrayRef<Attribute>, SmallVectorImpl<InvocationBounds> &invocationBounds) {
+  invocationBounds.push_back({1, 1});
+}
+
+//===----------------------------------------------------------------------===//
+// TensorMicrokernelOp::BufferizableOpInterface
+//===----------------------------------------------------------------------===//
+
+AliasingOpOperandList
+TensorMicrokernelOp::getAliasingOpOperands(Value value,
+                                           const AnalysisState &state) {
+  return {{
+      &getYieldOp()
+           .getResultsMutable()[cast<OpResult>(value).getResultNumber()],
+      BufferRelation::Equivalent,
+      /*isDefinite=*/true,
+  }};
+}
+
+FailureOr<BaseMemRefType>
+TensorMicrokernelOp::getBufferType(Value value,
+                                   const BufferizationOptions &options,
+                                   SmallVector<Value> &invocationStack) {
+  Value corresponding =
+      getYieldOp().getResults()[cast<OpResult>(value).getResultNumber()];
+  if (auto memRefType = dyn_cast<BaseMemRefType>(corresponding.getType()))
+    return memRefType;
+
+  return bufferization::getBufferType(corresponding, options, invocationStack);
+}
+
+LogicalResult
+TensorMicrokernelOp::bufferize(RewriterBase &rewriter,
+                               const BufferizationOptions &options) {
+  SmallVector<Value> newYields;
+  for (Value result : getYieldOp().getResults()) {
+    if (!isa<TensorType>(result.getType())) {
+      newYields.push_back(result);
+      continue;
+    }
+    auto bufferType = bufferization::getBuffer(rewriter, result, options);
+    if (failed(bufferType))
+      return failure();
+    newYields.push_back(*bufferType);
+  }
+
+  SetVector<Value> inputs;
+  WalkResult walkResult = walk([&](Operation *operation) {
+    for (Value value : operation->getOperands()) {
+      if (isa<TensorType>(value.getType())) {
+        FailureOr<Value> newInput = getBuffer(rewriter, value, options);
+        if (failed(newInput))
+          return WalkResult::interrupt();
+        value = *newInput;
+      }
+
+      if (getBody().isAncestor(value.getParentRegion()))
+        continue;
+      inputs.insert(value);
+    }
+    return WalkResult::advance();
+  });
+  if (walkResult.wasInterrupted())
+    return failure();
+
+  auto replacement = rewriter.create<MemRefMicrokernelOp>(
+      getLoc(), llvm::map_to_vector(newYields, std::mem_fn(&Value::getType)),
+      inputs.getArrayRef());
+  Block *newBlock = replacement.createEntryBlock();
+  {
+    OpBuilder::InsertionGuard guard{rewriter};
+    rewriter.setInsertionPointToStart(newBlock);
+
+    rewriter.mergeBlocks(&getBody().front(), newBlock);
+    rewriter.modifyOpInPlace(replacement.getYieldOp(), [&] {
+      replacement.getYieldOp().getResultsMutable().assign(newYields);
+    });
+
+    SmallVector<Value> vector = inputs.takeVector();
+    rewriter.setInsertionPointToStart(newBlock);
+    for (auto [oldV, newV] : llvm::zip(vector, newBlock->getArguments()))
+      rewriter.replaceUsesWithIf(oldV, newV, [&](OpOperand &operand) {
+        return replacement.getBody().isAncestor(
+            operand.getOwner()->getParentRegion());
+      });
+  }
+
+  replaceOpWithBufferizedValues(rewriter, *this, replacement.getResults());
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// MicrokernelYieldOp::BufferizableOpInterface
+//===----------------------------------------------------------------------===//
+
+bool MicrokernelYieldOp::bufferizesToMemoryRead(
+    OpOperand &, const bufferization::AnalysisState &) {
+  return false;
+}
+
+bool MicrokernelYieldOp::bufferizesToMemoryWrite(OpOperand &,
+                                                 const AnalysisState &) {
+  return false;
+}
+
+AliasingValueList MicrokernelYieldOp::getAliasingValues(OpOperand &opOperand,
+                                                        const AnalysisState &) {
+  return {{(*this)->getParentOp()->getResult(opOperand.getOperandNumber()),
+           BufferRelation::Equivalent, /*isDefinite=*/true}};
+}
+
+bool MicrokernelYieldOp::mustBufferizeInPlace(OpOperand &,
+                                              const AnalysisState &) {
+  // Yield operands always bufferize inplace. Otherwise, an alloc + copy
+  // may be generated inside the block. We should not return/yield allocations
+  // when possible.
+  return true;
+}
+
+LogicalResult
+MicrokernelYieldOp::bufferize(RewriterBase &rewriter,
+                              const BufferizationOptions &options) {
+  SmallVector<Value> newResults;
+  for (auto &&[index, value] : llvm::enumerate(getResults())) {
+    if (!isa<TensorType>(value.getType())) {
+      newResults.push_back(value);
+      continue;
+    }
+
+    FailureOr<Value> maybeBuffer = getBuffer(rewriter, value, options);
+    if (failed(maybeBuffer))
+      return failure();
+
+    newResults.push_back(*maybeBuffer);
+  }
+  replaceOpWithNewBufferizedOp<MicrokernelYieldOp>(rewriter, *this, newResults);
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// MemRefMicrokernelOp
+//===----------------------------------------------------------------------===//
+
+MicrokernelYieldOp MemRefMicrokernelOp::getYieldOp() {
+  return llvm::cast<MicrokernelYieldOp>(getBody().back().getTerminator());
+}
+
+Block *MemRefMicrokernelOp::createEntryBlock() {
   assert(getBody().getBlocks().empty());
   Block &block = getBody().emplaceBlock();
   block.addArguments(getInputs().getTypes(),
@@ -16,10 +179,30 @@ Block *XDSLKernelOp::createEntryBlock() {
   return &block;
 }
 
-LogicalResult XDSLKernelOp::verify() {
-  // TODO: Weaken this in the future to likely only require element count and
-  //  type but not the shape. TBD.
+LogicalResult MemRefMicrokernelOp::verify() {
   if (getBody().getArgumentTypes() != getInputs().getTypes())
     return emitOpError("type of arguments and inputs must match");
   return success();
+}
+
+//===----------------------------------------------------------------------===//
+// MemRefMicrokernelOp::RegionBranchOpInterface
+//===----------------------------------------------------------------------===//
+
+void MemRefMicrokernelOp::getSuccessorRegions(
+    RegionBranchPoint point, SmallVectorImpl<RegionSuccessor> &regions) {
+  if (point.isParent()) {
+    regions.emplace_back(&getBody(), getBody().getArguments());
+    return;
+  }
+  regions.emplace_back(getResults());
+}
+
+OperandRange MemRefMicrokernelOp::getEntrySuccessorOperands(RegionBranchPoint) {
+  return getInputsMutable();
+}
+
+void MemRefMicrokernelOp::getRegionInvocationBounds(
+    ArrayRef<Attribute>, SmallVectorImpl<InvocationBounds> &invocationBounds) {
+  invocationBounds.push_back({1, 1});
 }

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.h
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.h
@@ -2,9 +2,12 @@
 #pragma once
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "Quidditch/Dialect/Snitch/QuidditchSnitchOps.h.inc"

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.td
@@ -2,33 +2,79 @@
 #define QUIDDITCH_DIALECT_SNITCH_QUIDDITCHSNITCHOPS
 
 include "Quidditch/Dialect/Snitch/QuidditchSnitchDialect.td"
+include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 
 class QuidditchSnitch_Op<string mnemonic, list<Trait> traits = []> :
   Op<QuidditchSnitch_Dialect, mnemonic, traits>;
 
-// TODO: We likely want this in DPS and operating on tensors depending on the
-// phase of our compiler where we introduce these.
-def QuidditchSnitch_XDSLKernelOp : QuidditchSnitch_Op<"xdsl_kernel",
-  [IsolatedFromAbove, SingleBlock, NoTerminator]> {
+def QuidditchSnitch_TensorMicrokernelOp : QuidditchSnitch_Op<"tensor.microkernel",
+  [SingleBlock, NoRegionArguments,
+   DeclareOpInterfaceMethods<RegionBranchOpInterface, [
+    "getRegionInvocationBounds"]>,
+   DeclareOpInterfaceMethods<BufferizableOpInterface, ["bufferize",
+    "getAliasingOpOperands", "getBufferType"]>]> {
 
   let description = [{
 
   }];
 
-  let arguments = (ins Variadic<AnyShaped>:$inputs);
+  let results = (outs Variadic<AnyType>:$results);
 
   let regions = (region SizedRegion<1>:$body);
 
   let assemblyFormat = [{
-    `` `(` $inputs `)` `:` type($inputs) $body attr-dict
+    (`->` type($results)^ )? $body attr-dict
+  }];
+
+  let extraClassDeclaration = [{
+    MicrokernelYieldOp getYieldOp() {
+      return llvm::cast<MicrokernelYieldOp>(getBody().back().getTerminator());
+    }
+  }];
+}
+
+def QuidditchSnitch_MicrokernelYieldOp
+  : QuidditchSnitch_Op<"microkernel_yield", [Pure, Terminator,
+    ParentOneOf<["TensorMicrokernelOp", "MemRefMicrokernelOp"]>, ReturnLike,
+    DeclareOpInterfaceMethods<BufferizableOpInterface,
+      ["bufferize", "bufferizesToMemoryRead", "bufferizesToMemoryWrite",
+       "getAliasingValues", "mustBufferizeInPlace"]>]> {
+  let arguments = (ins Variadic<AnyType>:$results);
+
+  let assemblyFormat = [{
+    $results (`:` type($results)^)? attr-dict
+  }];
+}
+
+def QuidditchSnitch_MemRefMicrokernelOp
+  : QuidditchSnitch_Op<"memref.microkernel", [IsolatedFromAbove, SingleBlock,
+      DeclareOpInterfaceMethods<RegionBranchOpInterface,
+        ["getEntrySuccessorOperands", "getRegionInvocationBounds"]>]> {
+
+  let description = [{
+
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$inputs);
+
+  let results = (outs Variadic<AnyType>:$results);
+
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = [{
+    `` `(` $inputs `)` `:` functional-type($inputs, $results) $body attr-dict
   }];
 
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
+
+    MicrokernelYieldOp getYieldOp();
 
     mlir::Block* createEntryBlock();
   }];

--- a/codegen/tests/Dialect/Snitch/bufferization.mlir
+++ b/codegen/tests/Dialect/Snitch/bufferization.mlir
@@ -1,0 +1,23 @@
+// RUN: quidditch-opt %s --one-shot-bufferize | FileCheck %s
+
+// CHECK: func @test
+func.func @test(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
+  // CHECK: %[[ARG0:.*]] = bufferization.to_memref
+  // CHECK: %[[INIT:.*]] = memref.alloc()
+  %init = tensor.empty() : tensor<32xf32>
+  // CHECK: quidditch_snitch.memref.microkernel(%[[ARG0]], %[[INIT]])
+  %0 = quidditch_snitch.tensor.microkernel -> tensor<32xf32> {
+    // CHECK-NEXT: ^{{.*}}(%[[ARG1:.*]]: memref<{{.*}}>, %[[ARG2:.*]]: memref<{{.*}}>):
+    %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+      iterator_types = ["parallel"]
+    } ins(%arg0 : tensor<32xf32>) outs(%init : tensor<32xf32>) {
+    ^bb0(%in : f32, %out : f32):
+      %o = arith.addf %in, %in : f32
+      linalg.yield %o : f32
+    } -> tensor<32xf32>
+    // CHECK: quidditch_snitch.microkernel_yield %[[ARG2]]
+    quidditch_snitch.microkernel_yield %1 : tensor<32xf32>
+  }
+  return %0 : tensor<32xf32>
+}

--- a/codegen/tests/Dialect/Snitch/roundtrip.mlir
+++ b/codegen/tests/Dialect/Snitch/roundtrip.mlir
@@ -1,9 +1,16 @@
 // RUN: quidditch-opt %s --verify-roundtrip
 
 func.func @test(%arg0 : memref<f64>) {
-  quidditch_snitch.xdsl_kernel(%arg0) : memref<f64> {
+  quidditch_snitch.memref.microkernel(%arg0) : (memref<f64>) -> () {
   ^bb0(%arg1 : memref<f64>):
+    quidditch_snitch.microkernel_yield
+  }
+  return
+}
 
+func.func @test2(%arg0 : tensor<f64>) {
+  %0 = quidditch_snitch.tensor.microkernel -> tensor<f64> {
+    quidditch_snitch.microkernel_yield %arg0 : tensor<f64>
   }
   return
 }

--- a/codegen/tools/quidditch-opt.cpp
+++ b/codegen/tools/quidditch-opt.cpp
@@ -4,6 +4,8 @@
 #include <Quidditch/Dialect/Snitch/QuidditchSnitchDialect.h>
 #include <Quidditch/Target/Passes.h>
 
+#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
+
 namespace quidditch {
 #define GEN_PASS_REGISTRATION
 #include "Quidditch/Target/Passes.h.inc"
@@ -19,6 +21,7 @@ int main(int argc, char **argv) {
   registry.insert<quidditch::Snitch::QuidditchSnitchDialect>();
 
   quidditch::registerPasses();
+  mlir::bufferization::registerBufferizationPasses();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(
       argc, argv, "MLIR modular optimizer driver\n", registry));


### PR DESCRIPTION
By making it possible to bufferize the operations we are able to form our micro kernels earlier in the pass pipeline prior to bufferization. This is required for other transformation passes such as explicit tensor promotion to L1 memory and subgroup distribution that we are planning to add later.

As a consequence of this change the existing `xdsl_kernel` (now renamed to just `microkernel`) had to be split into two operations, one operating on tensors, the other on memrefs. The reason for this is that the memref version should be isolated from above while the tensor version cannot be for bufferization purposes. The bufferization process itself now converts between the two.