### PR TITLE
[quidditch_snitch] Implement canonicalization for memref microkernels

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/QuidditchSnitchOps.td
@@ -71,6 +71,7 @@ def QuidditchSnitch_MemRefMicrokernelOp
   }];
 
   let hasVerifier = 1;
+  let hasCanonicalizer = 1;
 
   let extraClassDeclaration = [{
 

--- a/codegen/tools/quidditch-opt.cpp
+++ b/codegen/tools/quidditch-opt.cpp
@@ -5,6 +5,7 @@
 #include <Quidditch/Target/Passes.h>
 
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
+#include "mlir/Transforms/Passes.h"
 
 namespace quidditch {
 #define GEN_PASS_REGISTRATION
@@ -22,6 +23,7 @@ int main(int argc, char **argv) {
 
   quidditch::registerPasses();
   mlir::bufferization::registerBufferizationPasses();
+  mlir::registerTransformsPasses();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(
       argc, argv, "MLIR modular optimizer driver\n", registry));


### PR DESCRIPTION
These canonicalizations help to get the microkernel into a minimal form to microoptimize the xDSL generation and also avoid hitting code generation limits. They mostly remove redundant arguments and results.