### PR TITLE
[quidditch_snitch] Add `l1_memory_view` op

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Conversion/CMakeLists.txt
@@ -6,7 +6,7 @@ iree_tablegen_library(
         TD_FILE
         "Passes.td"
         OUTS
-        --gen-pass-decls Passes.h.inc
+        -name=Conversion --gen-pass-decls Passes.h.inc
 )
 
 iree_cc_library(
@@ -22,4 +22,22 @@ iree_cc_library(
         Quidditch::Dialect::Snitch::IR::QuidditchSnitchDialect
         MLIRFuncDialect
         MLIRIR
+)
+
+iree_cc_library(
+        NAME
+        ConvertSnitchToLLVM
+        HDRS
+        "Passes.h"
+        "Passes.h.inc"
+        SRCS
+        "ConvertSnitchToLLVM.cpp"
+        DEPS
+        ::PassesIncGen
+        Quidditch::Dialect::Snitch::IR::QuidditchSnitchDialect
+        MLIRAnalysis
+        MLIRIR
+        MLIRLLVMCommonConversion
+        MLIRLLVMDialect
+        MLIRTransforms
 )

--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -1,0 +1,84 @@
+#include "Passes.h"
+
+#include "mlir/Analysis/DataLayoutAnalysis.h"
+#include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
+#include "mlir/Conversion/LLVMCommon/LoweringOptions.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
+
+namespace quidditch {
+#define GEN_PASS_DEF_CONVERTSNITCHTOLLVMPASS
+#include "Quidditch/Conversion/Passes.h.inc"
+} // namespace quidditch
+
+namespace {
+class ConvertSnitchToLLVM
+    : public quidditch::impl::ConvertSnitchToLLVMPassBase<ConvertSnitchToLLVM> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+using namespace mlir;
+using namespace quidditch::Snitch;
+
+namespace {
+struct L1MemoryViewOpLowering : ConvertOpToLLVMPattern<L1MemoryViewOp> {
+  using ConvertOpToLLVMPattern<L1MemoryViewOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(L1MemoryViewOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Value, 4> sizes;
+    SmallVector<Value, 4> strides;
+    Value size;
+
+    this->getMemRefDescriptorSizes(op->getLoc(), op.getType(),
+                                   adaptor.getOperands(), rewriter, sizes,
+                                   strides, size);
+
+    // TODO: This is horribly hardcoded when it shouldn't be.
+    Value l1Address = rewriter.create<LLVM::ConstantOp>(
+        op->getLoc(), rewriter.getI32IntegerAttr(0x10000000));
+    Value allocatedPtr = rewriter.create<LLVM::IntToPtrOp>(
+        op->getLoc(), rewriter.getType<LLVM::LLVMPointerType>(), l1Address);
+
+    auto memRefDescriptor =
+        this->createMemRefDescriptor(op->getLoc(), op.getType(), allocatedPtr,
+                                     allocatedPtr, sizes, strides, rewriter);
+
+    // Return the final value of the descriptor.
+    rewriter.replaceOp(op, {memRefDescriptor});
+    return success();
+  }
+};
+} // namespace
+
+void ConvertSnitchToLLVM::runOnOperation() {
+
+  const auto &dataLayoutAnalysis = getAnalysis<DataLayoutAnalysis>();
+  LowerToLLVMOptions options(&getContext(),
+                             dataLayoutAnalysis.getAtOrAbove(getOperation()));
+  // TODO: This is horribly hardcoded when it shouldn't be.
+  options.overrideIndexBitwidth(32);
+  LLVMTypeConverter typeConverter(&getContext(), options, &dataLayoutAnalysis);
+
+  RewritePatternSet patterns(&getContext());
+  patterns.insert<L1MemoryViewOpLowering>(typeConverter);
+
+  LLVMConversionTarget target(getContext());
+  target.markUnknownOpDynamicallyLegal([](auto) { return true; });
+  target.addIllegalDialect<QuidditchSnitchDialect>();
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}

--- a/codegen/compiler/src/Quidditch/Conversion/Passes.td
+++ b/codegen/compiler/src/Quidditch/Conversion/Passes.td
@@ -18,4 +18,11 @@ def ConvertToRISCVPass : Pass<"quidditch-convert-to-riscv", "mlir::ModuleOp"> {
   ];
 }
 
+def ConvertSnitchToLLVMPass
+    : Pass<"quidditch-convert-snitch-to-llvm", "mlir::ModuleOp"> {
+  let dependentDialects = [
+    "mlir::LLVM::LLVMDialect",
+  ];
+}
+
 #endif

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -81,4 +81,16 @@ def QuidditchSnitch_MemRefMicrokernelOp
   }];
 }
 
+def FlatI8MemRef : ConfinedType<MemRefOf<[I8]>, [HasStaticShapePred,
+  HasAnyRankOfPred<[1]>], "one-dimensional i8 MemRef of a static size">;
+
+def QuidditchSnitch_L1MemoryViewOp : QuidditchSnitch_Op<"l1_memory_view",
+  [Pure]> {
+  let results = (outs FlatI8MemRef:$result);
+
+  let assemblyFormat = [{
+    `->` type($result) attr-dict
+  }];
+}
+
 #endif

--- a/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
         DEPS
         ::Passes
         Quidditch::Conversion::ConvertToRISCV
+        Quidditch::Conversion::ConvertSnitchToLLVM
         IREELinalgTransformDialect
         LLVMAnalysis
         LLVMBitReader

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -184,8 +184,8 @@ public:
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass);
 
-    modulePassManager.addPass(
-        createConvertToLLVMPass(/*reassociateFpReordering=*/false));
+    modulePassManager.addPass(quidditch::createConvertSnitchToLLVMPass());
+    modulePassManager.addPass(createConvertToLLVMPass({}));
     modulePassManager.addPass(createReconcileUnrealizedCastsPass());
     // We rely on MLIR symbol visibility being correct after this point and
     // need to mirror the LLVM linkage that was assigned during conversion.

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -127,8 +127,17 @@ public:
       MLIRContext *context, StringRef deviceID, DictionaryAttr deviceConfigAttr,
       SmallVectorImpl<IREE::HAL::ExecutableTargetAttr> &executableTargetAttrs)
       const override {
-    executableTargetAttrs.push_back(
-        IREE::HAL::ExecutableTargetAttr::get(context, "quidditch", "static"));
+
+    NamedAttrList list;
+    // Target attribute info used by the LLVM lowering.
+    // TODO: Ideally shouldn't be hardcoded.
+    list.append("data_layout",
+                StringAttr::get(context, "e-m:e-p:32:32-i64:64-n32-S128"));
+    list.append("target_triple",
+                StringAttr::get(context, "riscv32-unknown-elf"));
+    executableTargetAttrs.push_back(IREE::HAL::ExecutableTargetAttr::get(
+        context, StringAttr::get(context, "quidditch"),
+        StringAttr::get(context, "static"), list.getDictionary(context)));
   }
 
   void buildTranslationPassPipeline(IREE::HAL::ExecutableTargetAttr targetAttr,

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/l1_memory_view.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/l1_memory_view.mlir
@@ -1,0 +1,19 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test() -> memref<32xi8> {
+  // CHECK-DAG: %[[DIM:.*]] = llvm.mlir.constant(32 : index)
+  // CHECK-DAG: %[[STRIDE:.*]] = llvm.mlir.constant(1 : index)
+  // CHECK: %[[L1_ADDRESS:.*]] = llvm.mlir.constant({{[0-9]+}} : i32)
+  // CHECK: %[[PTR:.*]] = llvm.inttoptr %[[L1_ADDRESS]]
+  // CHECK: %[[UNDEF:.*]] = llvm.mlir.undef
+  // CHECK: %[[DESC1:.*]] = llvm.insertvalue %[[PTR]], %[[UNDEF]][0]
+  // CHECK: %[[DESC2:.*]] = llvm.insertvalue %[[PTR]], %[[DESC1]][1]
+  // CHECK: %[[OFFSET:.*]] = llvm.mlir.constant(0 : index)
+  // CHECK: %[[DESC3:.*]] = llvm.insertvalue %[[OFFSET]], %[[DESC2]][2]
+  // CHECK: %[[DESC4:.*]] = llvm.insertvalue %[[DIM]], %[[DESC3]][3, 0]
+  // CHECK: %[[DESC5:.*]] = llvm.insertvalue %[[STRIDE]], %[[DESC4]][4, 0]
+  // CHECK: builtin.unrealized_conversion_cast %[[DESC5]]
+  %0 = quidditch_snitch.l1_memory_view -> memref<32xi8>
+  return %0 : memref<32xi8>
+}

--- a/codegen/tools/CMakeLists.txt
+++ b/codegen/tools/CMakeLists.txt
@@ -2,6 +2,8 @@ add_executable(quidditch-opt quidditch-opt.cpp)
 target_link_libraries(quidditch-opt
         PRIVATE
         MLIROptLib
+        Quidditch::Conversion::ConvertSnitchToLLVM
+        Quidditch::Conversion::ConvertToRISCV
         Quidditch::Dialect::Snitch::IR::QuidditchSnitchDialect
         Quidditch::Target::Passes
         iree::compiler::Dialect::LinalgExt::IR

--- a/codegen/tools/quidditch-opt.cpp
+++ b/codegen/tools/quidditch-opt.cpp
@@ -1,8 +1,9 @@
 #include <iree/compiler/Tools/init_dialects.h>
 #include <mlir/Tools/mlir-opt/MlirOptMain.h>
 
-#include <Quidditch/Target/Passes.h>
+#include "Quidditch/Conversion/Passes.h"
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
+#include "Quidditch/Target/Passes.h"
 
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
 #include "mlir/Transforms/Passes.h"
@@ -10,6 +11,8 @@
 namespace quidditch {
 #define GEN_PASS_REGISTRATION
 #include "Quidditch/Target/Passes.h.inc"
+#define GEN_PASS_REGISTRATION
+#include "Quidditch/Conversion/Passes.h.inc"
 } // namespace quidditch
 
 using namespace mlir;
@@ -22,6 +25,7 @@ int main(int argc, char **argv) {
   registry.insert<quidditch::Snitch::QuidditchSnitchDialect>();
 
   quidditch::registerPasses();
+  quidditch::registerConversionPasses();
   mlir::bufferization::registerBufferizationPasses();
   mlir::registerTransformsPasses();
 


### PR DESCRIPTION
This operation is used to represent L1 memory as one single large i8 memref. Allocation within L1 is then simply a `memref.view` into this memref. This PR also implements lowering it to LLVM.

Note that the operation always returns the same memref descriptor, i.e. the memref being returned aliases all other memrefs returned by the operation.