### PR TITLE
[quidditch_snitch] Implement tensor promotion to L1

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
@@ -11,8 +11,7 @@ def QuidditchSnitch_L1EncodingAttr : QuidditchSnitch_Attr<"L1Encoding"> {
   let mnemonic = "l1_encoding";
 
   let description = [{
-    Attribute used as both encoding on a tensor and memory space on a memref
-    to denote either of these being in L1 memory.
+    Attribute used as memory space on a memref to denote it being in L1 memory.
   }];
 }
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -81,6 +81,32 @@ def QuidditchSnitch_MemRefMicrokernelOp
   }];
 }
 
+def QuidditchSnitch_CopyL1TensorOp : QuidditchSnitch_Op<"copy_l1_tensor",
+  [SameOperandsAndResultType,
+   DeclareOpInterfaceMethods<BufferizableOpInterface,
+    ["resultBufferizesToMemoryWrite", "bufferizesToMemoryRead",
+     "bufferizesToMemoryWrite", "getAliasingValues", "getBufferType",
+      "bufferize"]>]> {
+
+  let description = [{
+    Operation performing copies of tensors between memory spaces.
+    If `$transfer_to_l1` is true, then the op ensures that the resulting tensor
+    is in L1.
+    Otherwise, the output tensor is guaranteed to be in L3 memory.
+    This operation is a noop if `$copy` and `$result` are already in the same
+    memory space.
+  }];
+
+  // TODO: Not a big fan of the UnitAttr. This should be an enum.
+  let arguments = (ins AnyStaticShapeTensor:$copy, UnitAttr:$transfer_to_l1);
+
+  let results = (outs AnyStaticShapeTensor:$result);
+
+  let assemblyFormat = [{
+    $copy (`to` `L1` $transfer_to_l1^) : (`from` `L1`)? `:` type($copy) attr-dict
+  }];
+}
+
 def FlatI8MemRef : ConfinedType<MemRefOf<[I8]>, [HasStaticShapePred,
   HasAnyRankOfPred<[1]>], "one-dimensional i8 MemRef of a static size">;
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -103,7 +103,7 @@ def QuidditchSnitch_CopyL1TensorOp : QuidditchSnitch_Op<"copy_l1_tensor",
   let results = (outs AnyStaticShapeTensor:$result);
 
   let assemblyFormat = [{
-    $copy (`to` `L1` $transfer_to_l1^) : (`from` `L1`)? `:` type($copy) attr-dict
+    $copy `to` ( `L1` $transfer_to_l1^) : (`L3`)? `:` type($copy) attr-dict
   }];
 }
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_cc_library(
         "Passes.h"
         "Passes.h.inc"
         SRCS
+        "PromoteToL1.cpp"
         "LowerL1Allocations.cpp"
         DEPS
         ::PassesIncGen

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
@@ -3,6 +3,13 @@
 
 include "mlir/Pass/PassBase.td"
 
+def PromoteToL1Pass : Pass<"quidditch-promote-to-l1"> {
+  let description = [{
+    Ensures that all tensors used within a microkernel are placed in L1 memory,
+    using copies if necessary.
+  }];
+}
+
 def LowerL1AllocationsPass : InterfacePass<"quidditch-lower-l1-allocations",
   "mlir::FunctionOpInterface"> {
   let description = [{

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PromoteToL1.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PromoteToL1.cpp
@@ -1,0 +1,77 @@
+#include "Passes.h"
+
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.h"
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+
+namespace quidditch::Snitch {
+#define GEN_PASS_DEF_PROMOTETOL1PASS
+#include "Quidditch/Dialect/Snitch/Transforms/Passes.h.inc"
+} // namespace quidditch::Snitch
+
+namespace {
+class PromoteToL1
+    : public quidditch::Snitch::impl::PromoteToL1PassBase<PromoteToL1> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+using namespace mlir;
+using namespace quidditch::Snitch;
+
+void PromoteToL1::runOnOperation() {
+  // Change all allocas so far to be L1 allocations.
+  getOperation()->walk([&](bufferization::AllocTensorOp tensorOp) {
+    if (!tensorOp.getCopy()) {
+      tensorOp.setMemorySpaceAttr(L1EncodingAttr::get(tensorOp.getContext()));
+      return;
+    }
+
+    OpBuilder builder(tensorOp);
+    Value replacement = builder.create<CopyL1TensorOp>(
+        tensorOp.getLoc(), tensorOp, /*transfers_to_l1=*/true);
+    tensorOp.replaceAllUsesWith(replacement);
+    tensorOp.erase();
+  });
+
+  getOperation()->walk([&](TensorMicrokernelOp microkernelOp) {
+    // Insert copies from the L1 result back to the buffer ahead of replacing
+    // tensors.
+    auto builder = OpBuilder(microkernelOp->getContext());
+    builder.setInsertionPointAfter(microkernelOp);
+    for (Value result : microkernelOp.getResults()) {
+      if (!isa<RankedTensorType>(result.getType()))
+        continue;
+
+      auto copyOp = builder.create<CopyL1TensorOp>(result.getLoc(), result);
+      result.replaceAllUsesExcept(copyOp->getResult(0), copyOp);
+    }
+
+    SetVector<TypedValue<RankedTensorType>> nonL1Uses;
+    microkernelOp->walk([&](Operation *operation) {
+      for (Value operand : operation->getOperands())
+        if (isa<RankedTensorType>(operand.getType()) &&
+            !microkernelOp.getBody().isAncestor(operand.getParentRegion()))
+          nonL1Uses.insert(cast<TypedValue<RankedTensorType>>(operand));
+    });
+
+    if (nonL1Uses.empty())
+      return;
+
+    // Create copies into L1 for all tensors used in the kernel.
+    builder = OpBuilder(microkernelOp);
+    for (TypedValue<RankedTensorType> value : nonL1Uses) {
+      auto copyOp = builder.create<CopyL1TensorOp>(microkernelOp.getLoc(),
+                                                   /*copy=*/value,
+                                                   /*transfers_to_l1=*/true);
+      value.replaceUsesWithIf(copyOp, [&](OpOperand &operand) {
+        return microkernelOp.getBody().isAncestor(
+            operand.getOwner()->getParentRegion());
+      });
+    }
+  });
+}

--- a/codegen/tests/Dialect/Snitch/IR/bufferization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/bufferization.mlir
@@ -21,3 +21,36 @@ func.func @test(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
   }
   return %0 : tensor<32xf32>
 }
+
+// CHECK: func @copy_l1_buffer(
+func.func @copy_l1_buffer(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
+  // CHECK: %[[ARG0:.*]] = bufferization.to_memref
+
+  // CHECK: %[[ALLOC:.*]] = memref.alloc()
+  // CHECK-SAME: : memref<32xf32, #quidditch_snitch.l1_encoding>
+  // CHECK: memref.copy %[[ARG0]], %[[ALLOC]]
+  // CHECK: %[[R:.*]] = bufferization.to_tensor %[[ALLOC]]
+  %r = quidditch_snitch.copy_l1_tensor %arg0 to L1 : tensor<32xf32>
+  // CHECK: return %[[R]]
+  return %r : tensor<32xf32>
+}
+
+// CHECK: func @copy_l1_buffer_elided(
+func.func @copy_l1_buffer_elided(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
+  // CHECK: memref.alloc()
+  // CHECK-NOT: memref.alloc()
+  %r = quidditch_snitch.copy_l1_tensor %arg0 to L1 : tensor<32xf32>
+  %r2 = quidditch_snitch.copy_l1_tensor %r to L1 : tensor<32xf32>
+  // CHECK: return
+  return %r2 : tensor<32xf32>
+}
+
+// CHECK: func @copy_l1_buffer_alloca_elided(
+func.func @copy_l1_buffer_alloca_elided() -> tensor<32xf32> {
+  // CHECK: memref.alloc()
+  // CHECK-NOT: memref.alloc()
+  %r = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding} : tensor<32xf32>
+  %r2 = quidditch_snitch.copy_l1_tensor %r to L1 : tensor<32xf32>
+  // CHECK: return
+  return %r2 : tensor<32xf32>
+}

--- a/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
@@ -15,7 +15,7 @@ func.func @test(%a : tensor<32x32xf32>, %b : tensor<32x32xf32>) -> tensor<32x32x
     %r2 = linalg.matmul ins(%a, %b : tensor<32x32xf32>, tensor<32x32xf32>) outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
     quidditch_snitch.microkernel_yield %r2 : tensor<32x32xf32>
   }
-  // CHECK: %[[R2:.*]] = quidditch_snitch.copy_l1_tensor %[[R]] from L1
+  // CHECK: %[[R2:.*]] = quidditch_snitch.copy_l1_tensor %[[R]] to L3
   // CHECK: return %[[R2]]
   return %r : tensor<32x32xf32>
 }

--- a/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
@@ -1,0 +1,21 @@
+// RUN: quidditch-opt %s -p "builtin.module(func.func(quidditch-promote-to-l1))" | FileCheck %s
+
+// CHECK-LABEL: @test(
+// CHECK-SAME: %[[A:[[:alnum:]]+]]: tensor<32x32xf32>
+// CHECK-SAME: %[[B:[[:alnum:]]+]]: tensor<32x32xf32>
+func.func @test(%a : tensor<32x32xf32>, %b : tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: %[[E:.*]] = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding}
+  %e = bufferization.alloc_tensor() : tensor<32x32xf32>
+  // CHECK: %[[A2:.*]] = quidditch_snitch.copy_l1_tensor %[[A]] to L1
+  // CHECK: %[[B2:.*]] = quidditch_snitch.copy_l1_tensor %[[B]] to L1
+  // CHECK: %[[E2:.*]] = quidditch_snitch.copy_l1_tensor %[[E]] to L1
+  // CHECK: %[[R:.*]] = quidditch_snitch.tensor.microkernel
+  %r = quidditch_snitch.tensor.microkernel -> tensor<32x32xf32> {
+    // CHECK: linalg.matmul ins(%[[A2]], %[[B2]] : {{.*}}) outs(%[[E2]] : {{.*}})
+    %r2 = linalg.matmul ins(%a, %b : tensor<32x32xf32>, tensor<32x32xf32>) outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
+    quidditch_snitch.microkernel_yield %r2 : tensor<32x32xf32>
+  }
+  // CHECK: %[[R2:.*]] = quidditch_snitch.copy_l1_tensor %[[R]] from L1
+  // CHECK: return %[[R2]]
+  return %r : tensor<32x32xf32>
+}

--- a/runtime/samples/nsnet2/nsnet2_util.c
+++ b/runtime/samples/nsnet2/nsnet2_util.c
@@ -37,7 +37,6 @@ int run_nsnet2_experiment(
       .num_outputs = 1,
       .output_data = (void *[]){data},
       .output_sizes = (const iree_host_size_t[]){IREE_ARRAYSIZE(data)},
-      .device_allocator = l1_allocator(),
   };
 
   IREE_CHECK_OK(run_model(&config));

--- a/runtime/samples/util/run_model.h
+++ b/runtime/samples/util/run_model.h
@@ -39,21 +39,8 @@ typedef struct {
   void** output_data;
   /// Number of elements for each array in 'output_data'.
   const iree_host_size_t* output_sizes;
-
-  /// Allocator to use for "device" allocation.
-  iree_allocator_t device_allocator;
 } model_config_t;
 
 /// Runs the given IREE module according to the config. Input and output data
 /// are copied into and out of the given memory.
 iree_status_t run_model(const model_config_t* config);
-
-/// Allocator which allocates within TCDM (L1) memory. Required for features
-/// such as streaming registers.
-iree_allocator_t l1_allocator(void);
-
-/// Allocator which allocates within DRAM (L3) memory. Uses 'malloc' and 'free'
-/// behind the scenes.
-static inline iree_allocator_t l3_allocator(void) {
-  return iree_allocator_system();
-}

--- a/runtime/samples/vec_multiply/main.c
+++ b/runtime/samples/vec_multiply/main.c
@@ -36,7 +36,6 @@ int main() {
       .num_outputs = 1,
       .output_data = (void*[]){data},
       .output_sizes = (const iree_host_size_t[]){IREE_ARRAYSIZE(data)},
-      .device_allocator = l1_allocator(),
   };
 
   IREE_CHECK_OK(run_model(&config));


### PR DESCRIPTION
An invariant of our microkernels is that tensors MUST be in L1 memory or the execution will crash. This PR implements enforces this by adding and creating a new operation called `copy_l1_tensor` which is capable of transferring either from or to L1. During bufferization a copy is performed, if necessary, otherwise the operation is a noop. The `L1EncodingAttr` is used as memory space for L1 MemRefs during bufferization whose lowerings have been implemented in previous PRs.

With this PR it is now also possible to run kernels with buffers allocated in L3/DRAM as long as the used memory fits into L1.