### PR TITLE
[PromoteToL1] Don't copy buffer back into L3

### DIFF
--- a/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
@@ -15,7 +15,6 @@ func.func @test(%a : tensor<32x32xf32>, %b : tensor<32x32xf32>) -> tensor<32x32x
     %r2 = linalg.matmul ins(%a, %b : tensor<32x32xf32>, tensor<32x32xf32>) outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
     quidditch_snitch.microkernel_yield %r2 : tensor<32x32xf32>
   }
-  // CHECK: %[[R2:.*]] = quidditch_snitch.copy_l1_tensor %[[R]] to L3
-  // CHECK: return %[[R2]]
+  // CHECK: return %[[R]]
   return %r : tensor<32x32xf32>
 }


### PR DESCRIPTION
Whether the buffer should be copied and where it should be copied to should be decided by the consumer of the tensor, not the promotion logic. The bufferization framework actually does this for us and does so without introducing spurious copies as the current implementation would.