### PR TITLE
[compiler] Fork `LibraryBuilder` from `LLVMCPU`

### DIFF
--- a/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
         Quidditch
         SRCS
         "QuidditchTarget.cpp"
+        "LibraryBuilder.cpp"
         DEPS
         ::Passes
         Quidditch::Conversion::ConvertToRISCV

--- a/codegen/compiler/src/Quidditch/Target/LibraryBuilder.cpp
+++ b/codegen/compiler/src/Quidditch/Target/LibraryBuilder.cpp
@@ -1,0 +1,741 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "LibraryBuilder.h"
+
+#include "llvm/IR/IRBuilder.h"
+
+using namespace mlir;
+
+// =============================================================================
+//
+// NOTE: these structures model 1:1 those in iree/hal/local/executable_library.h
+//
+// This file must always track the latest version. Backwards compatibility with
+// existing runtimes using older versions of the header is maintained by
+// emitting variants of the structs matching those in the older headers and
+// selecting between them in the query function based on the requested version.
+//
+// =============================================================================
+
+namespace Quidditch {
+
+static inline int64_t roundUpToAlignment(int64_t value, int64_t alignment) {
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+//===----------------------------------------------------------------------===//
+// iree/hal/local/executable_library.h structure types
+//===----------------------------------------------------------------------===//
+// The IR snippets below were pulled from clang running with `-S -emit-llvm`
+// on the executable_library.h header: https://godbolt.org/z/6bMv5jfvf
+
+// %struct.iree_hal_executable_import_table_v0_t = type {
+//   i32,
+//   i8**
+// }
+static llvm::StructType *makeImportTableType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_import_table_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *i8PtrType = llvm::PointerType::getUnqual(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            i32Type,
+                                            i8PtrType->getPointerTo(),
+                                        },
+                                        "iree_hal_executable_import_table_v0_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_environment_v0_t = type {
+//   ...
+// }
+static llvm::StructType *makeEnvironmentType(llvm::LLVMContext &context) {
+  auto *type = llvm::StructType::getTypeByName(
+      context, "iree_hal_executable_environment_v0_t");
+  if (!type) {
+    type = llvm::StructType::create(context,
+                                    "iree_hal_executable_environment_v0_t");
+  }
+  return type;
+}
+
+// %struct.iree_hal_executable_dispatch_state_v0_t = type {
+//   ...
+// }
+static llvm::StructType *makeDispatchStateType(llvm::LLVMContext &context) {
+  auto *type = llvm::StructType::getTypeByName(
+      context, "iree_hal_executable_dispatch_state_v0_t");
+  if (!type) {
+    type = llvm::StructType::create(context,
+                                    "iree_hal_executable_dispatch_state_v0_t");
+  }
+  return type;
+}
+
+// %struct.iree_hal_executable_workgroup_state_v0_t = type {
+//   ...
+// }
+static llvm::StructType *makeWorkgroupStateType(llvm::LLVMContext &context) {
+  auto *type = llvm::StructType::getTypeByName(
+      context, "iree_hal_executable_workgroup_state_v0_t");
+  if (!type) {
+    type = llvm::StructType::create(context,
+                                    "iree_hal_executable_workgroup_state_v0_t");
+  }
+  return type;
+}
+
+// i32 (%struct.iree_hal_executable_environment_v0_t*,
+//      %struct.iree_hal_executable_dispatch_state_v0_t*,
+//      i8*)
+static llvm::FunctionType *
+makeDispatchFunctionType(llvm::LLVMContext &context) {
+  auto *environmentType = makeEnvironmentType(context);
+  auto *dispatchStateType = makeDispatchStateType(context);
+  auto *workgroupStateType = makeWorkgroupStateType(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  return llvm::FunctionType::get(i32Type,
+                                 {
+                                     environmentType->getPointerTo(),
+                                     dispatchStateType->getPointerTo(),
+                                     workgroupStateType->getPointerTo(),
+                                 },
+                                 /*isVarArg=*/false);
+}
+
+// %struct.iree_hal_executable_dispatch_attrs_v0_t = type {
+//   i16,
+//   i16
+// }
+static llvm::StructType *makeDispatchAttrsType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_dispatch_attrs_v0_t")) {
+    return existingType;
+  }
+  auto *i16Type = llvm::IntegerType::getInt16Ty(context);
+  auto *type =
+      llvm::StructType::create(context,
+                               {
+                                   i16Type,
+                                   i16Type,
+                               },
+                               "iree_hal_executable_dispatch_attrs_v0_t",
+                               /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_source_location_v0_t = type {
+//   i32,
+//   i32,
+//   i8*
+// }
+static llvm::StructType *makeSourceLocationType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_source_location_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *i8PtrType = llvm::PointerType::getUnqual(context);
+  auto *type =
+      llvm::StructType::create(context,
+                               {
+                                   i32Type,
+                                   i32Type,
+                                   i8PtrType,
+                               },
+                               "iree_hal_executable_source_location_v0_t",
+                               /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_stage_location_table_v0_t = type {
+//   i32,
+//   i8**,
+//   %struct.iree_hal_executable_source_location_v0_t*,
+// }
+static llvm::StructType *
+makeStageLocationTableType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_stage_location_table_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *i8PtrType = llvm::PointerType::getUnqual(context);
+  auto *sourceLocationType = makeSourceLocationType(context);
+  auto *type =
+      llvm::StructType::create(context,
+                               {
+                                   i32Type,
+                                   i8PtrType->getPointerTo(),
+                                   sourceLocationType->getPointerTo(),
+                               },
+                               "iree_hal_executable_stage_location_table_v0_t",
+                               /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_export_table_v0_t = type {
+//   i32,
+//   i32*,
+//   %struct.iree_hal_executable_dispatch_attrs_v0_t*,
+//   i8**,
+//   i8**,
+//   %struct.iree_hal_executable_source_location_v0_t*,
+//   %struct.iree_hal_executable_stage_location_table_v0_t*,
+// }
+static llvm::StructType *makeExportTableType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_export_table_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *dispatchFunctionType = makeDispatchFunctionType(context);
+  auto *dispatchAttrsType = makeDispatchAttrsType(context);
+  auto *i8PtrType = llvm::PointerType::getUnqual(context);
+  auto *sourceLocationType = makeSourceLocationType(context);
+  auto *stageLocationTableType = makeStageLocationTableType(context);
+  auto *type = llvm::StructType::create(
+      context,
+      {
+          i32Type,
+          dispatchFunctionType->getPointerTo()->getPointerTo(),
+          dispatchAttrsType->getPointerTo(),
+          i8PtrType->getPointerTo(),
+          i8PtrType->getPointerTo(),
+          sourceLocationType->getPointerTo(),
+          stageLocationTableType->getPointerTo(),
+      },
+      "iree_hal_executable_export_table_v0_t",
+      /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_constant_table_v0_t = type {
+//   i32
+// }
+static llvm::StructType *makeConstantTableType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_constant_table_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *type =
+      llvm::StructType::create(context,
+                               {
+                                   i32Type,
+                               },
+                               "iree_hal_executable_constant_table_v0_t",
+                               /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_source_file_v0_t = type {
+//   i32,
+//   i8*,
+//   i32,
+//   i8*
+// }
+static llvm::StructType *makeSourceFileType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_source_file_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *i8PtrType = llvm::PointerType::getUnqual(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            i32Type,
+                                            i8PtrType,
+                                            i32Type,
+                                            i8PtrType,
+                                        },
+                                        "iree_hal_executable_source_file_v0_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_source_file_table_v0_t = type {
+//   i32,
+//   %struct.iree_hal_executable_source_file_v0_t*,
+// }
+static llvm::StructType *makeSourceTableType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_source_file_table_v0_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *sourceFileType = makeSourceFileType(context);
+  auto *type =
+      llvm::StructType::create(context,
+                               {
+                                   i32Type,
+                                   sourceFileType->getPointerTo(),
+                               },
+                               "iree_hal_executable_source_file_table_v0_t",
+                               /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_library_header_t = type {
+//   i32,
+//   i8*,
+//   i32,
+//   i32
+// }
+static llvm::StructType *makeLibraryHeaderType(llvm::LLVMContext &context) {
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_library_header_t")) {
+    return existingType;
+  }
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *i8PtrType = llvm::PointerType::getUnqual(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            i32Type,
+                                            i8PtrType,
+                                            i32Type,
+                                            i32Type,
+                                        },
+                                        "iree_hal_executable_library_header_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+// %struct.iree_hal_executable_library_v0_t = type {
+//   %struct.iree_hal_executable_library_header_t*,
+//   %struct.iree_hal_executable_import_table_v0_t,
+//   %struct.iree_hal_executable_export_table_v0_t,
+// }
+static llvm::StructType *makeLibraryType(llvm::StructType *libraryHeaderType) {
+  auto &context = libraryHeaderType->getContext();
+  if (auto *existingType = llvm::StructType::getTypeByName(
+          context, "iree_hal_executable_library_v0_t")) {
+    return existingType;
+  }
+  auto *importTableType = makeImportTableType(context);
+  auto *exportTableType = makeExportTableType(context);
+  auto *constantTableType = makeConstantTableType(context);
+  auto *sourceTableType = makeSourceTableType(context);
+  auto *type = llvm::StructType::create(context,
+                                        {
+                                            libraryHeaderType->getPointerTo(),
+                                            importTableType,
+                                            exportTableType,
+                                            constantTableType,
+                                            sourceTableType,
+                                        },
+                                        "iree_hal_executable_library_v0_t",
+                                        /*isPacked=*/false);
+  return type;
+}
+
+//===----------------------------------------------------------------------===//
+// IR construction utilities
+//===----------------------------------------------------------------------===//
+
+// Creates a global NUL-terminated string constant.
+//
+// Example:
+//   @.str.2 = private unnamed_addr constant [6 x i8] c"lib_a\00", align 1
+static llvm::Constant *createStringConstant(StringRef value,
+                                            llvm::Module *module) {
+  auto i8Type = llvm::IntegerType::getInt8Ty(module->getContext());
+  auto i32Type = llvm::IntegerType::getInt32Ty(module->getContext());
+  auto *stringType = llvm::ArrayType::get(i8Type, value.size() + /*NUL*/ 1);
+  auto *literal =
+      llvm::ConstantDataArray::getString(module->getContext(), value);
+  auto *global = new llvm::GlobalVariable(*module, stringType,
+                                          /*isConstant=*/true,
+                                          llvm::GlobalVariable::PrivateLinkage,
+                                          literal, /*Name=*/"");
+  global->setAlignment(llvm::MaybeAlign(1));
+  llvm::Constant *zero = llvm::ConstantInt::get(i32Type, 0);
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(
+      stringType, global, ArrayRef<llvm::Constant *>{zero, zero});
+}
+
+// Creates a global NUL-terminated string constant or NULL if the string is
+// empty.
+static llvm::Constant *createStringConstantOrNull(StringRef value,
+                                                  llvm::Module *module) {
+  if (value.empty()) {
+    auto i8Type = llvm::IntegerType::getInt8Ty(module->getContext());
+    return llvm::ConstantPointerNull::get(i8Type->getPointerTo());
+  }
+  return createStringConstant(value, module);
+}
+
+// Creates a global serialized buffer constant (or string without NUL).
+//
+// Example:
+//   @.data = private unnamed_addr constant [5 x i8] c"lib_a", align 1
+static llvm::Constant *createBufferConstant(StringRef name,
+                                            ArrayRef<char> value,
+                                            llvm::Module *module) {
+  auto i8Type = llvm::IntegerType::getInt8Ty(module->getContext());
+  auto i32Type = llvm::IntegerType::getInt32Ty(module->getContext());
+  auto *bufferType = llvm::ArrayType::get(i8Type, value.size());
+  auto *literal = llvm::ConstantDataArray::get(module->getContext(), value);
+  auto *global = new llvm::GlobalVariable(
+      *module, bufferType,
+      /*isConstant=*/true, llvm::GlobalVariable::PrivateLinkage, literal, name);
+  global->setAlignment(llvm::MaybeAlign(1));
+  llvm::Constant *zero = llvm::ConstantInt::get(i32Type, 0);
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(
+      bufferType, global, ArrayRef<llvm::Constant *>{zero, zero});
+}
+
+// Creates a global constant with the given elements.
+static llvm::Constant *createArrayConstant(StringRef name,
+                                           llvm::Type *elementType,
+                                           ArrayRef<llvm::Constant *> elements,
+                                           llvm::Module *module) {
+  auto *i32Type = llvm::IntegerType::getInt32Ty(module->getContext());
+  llvm::Constant *zero = llvm::ConstantInt::get(i32Type, 0);
+  auto *arrayType = llvm::ArrayType::get(elementType, elements.size());
+  auto *global = new llvm::GlobalVariable(
+      *module, arrayType, /*isConstant=*/true,
+      llvm::GlobalVariable::PrivateLinkage,
+      llvm::ConstantArray::get(arrayType, elements), name);
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(
+      arrayType, global, ArrayRef<llvm::Constant *>{zero, zero});
+}
+
+//===----------------------------------------------------------------------===//
+// Builder interface
+//===----------------------------------------------------------------------===//
+
+llvm::Function *LibraryBuilder::build(StringRef queryFuncName) {
+  auto &context = module->getContext();
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  auto *environmentType = makeEnvironmentType(context)->getPointerTo();
+  auto *libraryHeaderType = makeLibraryHeaderType(context);
+
+  // %struct.iree_hal_executable_library_header_t**
+  // @iree_hal_library_query(i32, %struct.iree_hal_executable_environment_v0_t*)
+  auto *queryFuncType =
+      llvm::FunctionType::get(libraryHeaderType->getPointerTo(),
+                              {
+                                  i32Type,
+                                  environmentType,
+                              },
+                              /*isVarArg=*/false);
+  auto *func =
+      llvm::Function::Create(queryFuncType, llvm::GlobalValue::InternalLinkage,
+                             queryFuncName, *module);
+
+  auto *entryBlock = llvm::BasicBlock::Create(context, "entry", func);
+  llvm::IRBuilder<> builder(entryBlock);
+
+  // Build out the header for each version and select it at runtime.
+  // NOTE: today there is just one version so this is rather simple:
+  //   return max_version == 0 ? &library : NULL;
+  auto *v0 = buildLibraryV0((queryFuncName + "_v0").str());
+  builder.CreateRet(builder.CreateSelect(
+      builder.CreateICmpEQ(func->getArg(0),
+                           llvm::ConstantInt::get(
+                               i32Type, static_cast<int64_t>(Version::LATEST))),
+      builder.CreatePointerCast(v0, libraryHeaderType->getPointerTo()),
+      llvm::ConstantPointerNull::get(libraryHeaderType->getPointerTo())));
+
+  return func;
+}
+
+llvm::Constant *
+LibraryBuilder::buildLibraryV0ImportTable(std::string libraryName) {
+  auto &context = module->getContext();
+  auto *importTableType = makeImportTableType(context);
+  auto *i8Type = llvm::IntegerType::getInt8Ty(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  llvm::Constant *symbolNames =
+      llvm::Constant::getNullValue(i8Type->getPointerTo());
+  if (!imports.empty()) {
+    SmallVector<llvm::Constant *> symbolNameValues;
+    for (auto &import : imports) {
+      auto symbolName = import.symbol_name;
+      if (import.weak)
+        symbolName = "?" + symbolName;
+      symbolNameValues.push_back(createStringConstant(symbolName, module));
+    }
+    symbolNames =
+        createArrayConstant(libraryName + "_import_names",
+                            i8Type->getPointerTo(), symbolNameValues, module);
+  }
+  return llvm::ConstantStruct::get(
+      importTableType, {
+                           // count=
+                           llvm::ConstantInt::get(i32Type, imports.size()),
+                           // symbols=
+                           symbolNames,
+                       });
+}
+
+llvm::Constant *
+LibraryBuilder::buildLibraryV0ExportTable(std::string libraryName) {
+  auto &context = module->getContext();
+  auto *exportTableType = makeExportTableType(context);
+  auto *dispatchFunctionType = makeDispatchFunctionType(context);
+  auto *dispatchAttrsType = makeDispatchAttrsType(context);
+  auto *sourceLocationType = makeSourceLocationType(context);
+  auto *stageLocationTableType = makeStageLocationTableType(context);
+  auto *i8Type = llvm::IntegerType::getInt8Ty(context);
+  auto *i16Type = llvm::IntegerType::getInt16Ty(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+
+  // iree_hal_executable_export_table_v0_t::ptrs
+  SmallVector<llvm::Constant *> exportPtrValues;
+  for (auto dispatch : exports)
+    exportPtrValues.push_back(dispatch.func);
+  llvm::Constant *exportPtrs = createArrayConstant(
+      libraryName + "_funcs", dispatchFunctionType->getPointerTo(),
+      exportPtrValues, module);
+
+  // iree_hal_executable_export_table_v0_t::attrs
+  llvm::Constant *exportAttrs =
+      llvm::Constant::getNullValue(i32Type->getPointerTo());
+  bool hasNonDefaultAttrs = llvm::any_of(exports, [](const auto &dispatch) {
+    return !dispatch.attrs.isDefault();
+  });
+  if (!hasNonDefaultAttrs) {
+    SmallVector<llvm::Constant *> exportAttrValues;
+    for (auto dispatch : exports) {
+      exportAttrValues.push_back(llvm::ConstantStruct::get(
+          dispatchAttrsType,
+          {
+              // local_memory_pages=
+              llvm::ConstantInt::get(
+                  i16Type, roundUpToAlignment(dispatch.attrs.localMemorySize,
+                                              kWorkgroupLocalMemoryPageSize) /
+                               kWorkgroupLocalMemoryPageSize),
+              // reserved=
+              llvm::ConstantInt::get(i16Type, 0),
+          }));
+    }
+    exportAttrs = createArrayConstant(libraryName + "_attrs", dispatchAttrsType,
+                                      exportAttrValues, module);
+  }
+
+  // iree_hal_executable_export_table_v0_t::names
+  llvm::Constant *exportNames =
+      llvm::Constant::getNullValue(i8Type->getPointerTo()->getPointerTo());
+  if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
+    SmallVector<llvm::Constant *> exportNameValues;
+    for (auto dispatch : exports)
+      exportNameValues.push_back(createStringConstant(dispatch.name, module));
+    exportNames =
+        createArrayConstant(libraryName + "_names", i8Type->getPointerTo(),
+                            exportNameValues, module);
+  }
+
+  // iree_hal_executable_export_table_v0_t::tags
+  llvm::Constant *exportTags =
+      llvm::Constant::getNullValue(i8Type->getPointerTo()->getPointerTo());
+  bool hasAnyTags = llvm::any_of(
+      exports, [](auto &dispatch) { return !dispatch.tag.empty(); });
+  if (mode == Mode::INCLUDE_REFLECTION_ATTRS && hasAnyTags) {
+    SmallVector<llvm::Constant *> exportTagValues;
+    for (auto dispatch : exports)
+      exportTagValues.push_back(
+          createStringConstantOrNull(dispatch.tag, module));
+    exportTags = createArrayConstant(
+        libraryName + "_tags", i8Type->getPointerTo(), exportTagValues, module);
+  }
+
+  // iree_hal_executable_export_table_v0_t::source_locations
+  llvm::Constant *exportSourceLocations =
+      llvm::Constant::getNullValue(sourceLocationType->getPointerTo());
+  if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
+    SmallVector<llvm::Constant *> exportSourceLocationValues;
+    for (auto dispatch : exports) {
+      exportSourceLocationValues.push_back(llvm::ConstantStruct::get(
+          sourceLocationType,
+          {
+              // line=
+              llvm::ConstantInt::get(i32Type, dispatch.sourceLocation.line),
+              // path_length=
+              llvm::ConstantInt::get(i32Type,
+                                     dispatch.sourceLocation.path.size()),
+              // path=
+              createStringConstant(dispatch.sourceLocation.path, module),
+          }));
+    }
+    exportSourceLocations = createArrayConstant(
+        libraryName + "_source_locations", sourceLocationType,
+        exportSourceLocationValues, module);
+  }
+
+  // iree_hal_executable_export_table_v0_t::stage_locations
+  llvm::Constant *exportStageLocations =
+      llvm::Constant::getNullValue(stageLocationTableType->getPointerTo());
+  if (mode == Mode::INCLUDE_REFLECTION_ATTRS) {
+    SmallVector<llvm::Constant *> exportStageTableValues;
+    for (auto dispatch : exports) {
+      SmallVector<llvm::Constant *> exportStageNameValues;
+      SmallVector<llvm::Constant *> exportSourceLocationValues;
+      for (auto &stageLocation : dispatch.stageLocations) {
+        exportStageNameValues.push_back(
+            createStringConstant(stageLocation.stage, module));
+        exportSourceLocationValues.push_back(llvm::ConstantStruct::get(
+            sourceLocationType,
+            {
+                // line=
+                llvm::ConstantInt::get(i32Type, stageLocation.line),
+                // path_length=
+                llvm::ConstantInt::get(i32Type, stageLocation.path.size()),
+                // path=
+                createStringConstant(stageLocation.path, module),
+            }));
+      }
+      llvm::Constant *stageNamesPtr = createArrayConstant(
+          libraryName + "_" + dispatch.name + "_stage_names",
+          i8Type->getPointerTo(), exportStageNameValues, module);
+      llvm::Constant *sourceLocationsPtr = createArrayConstant(
+          libraryName + "_" + dispatch.name + "_stage_source_locations",
+          sourceLocationType, exportSourceLocationValues, module);
+      exportStageTableValues.push_back(llvm::ConstantStruct::get(
+          stageLocationTableType,
+          {
+              // count=
+              llvm::ConstantInt::get(i32Type, exportStageNameValues.size()),
+              // names=
+              stageNamesPtr,
+              // locations=
+              sourceLocationsPtr,
+          }));
+    }
+    if (!exportStageTableValues.empty()) {
+      exportStageLocations = createArrayConstant(
+          libraryName + "_stage_location_tables", stageLocationTableType,
+          exportStageTableValues, module);
+    }
+  }
+
+  return llvm::ConstantStruct::get(
+      exportTableType, {
+                           // count=
+                           llvm::ConstantInt::get(i32Type, exports.size()),
+                           // ptrs=
+                           exportPtrs,
+                           // attrs=
+                           exportAttrs,
+                           // names=
+                           exportNames,
+                           // tags=
+                           exportTags,
+                           // source_locations=
+                           exportSourceLocations,
+                           // stage_locations=
+                           exportStageLocations,
+                       });
+}
+
+llvm::Constant *
+LibraryBuilder::buildLibraryV0ConstantTable(std::string libraryName) {
+  auto &context = module->getContext();
+  auto *constantTableType = makeConstantTableType(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  return llvm::ConstantStruct::get(
+      constantTableType, {
+                             // count=
+                             llvm::ConstantInt::get(i32Type, constantCount),
+                         });
+}
+
+llvm::Constant *
+LibraryBuilder::buildLibraryV0SourceTable(std::string libraryName) {
+  auto &context = module->getContext();
+  auto *sourceFileType = makeSourceFileType(context);
+  auto *sourceTableType = makeSourceTableType(context);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+  llvm::Constant *sourceFilesValue =
+      llvm::Constant::getNullValue(sourceFileType->getPointerTo());
+  if (!sourceFiles.empty()) {
+    SmallVector<llvm::Constant *> sourceFileValues;
+    for (auto &sourceFile : sourceFiles) {
+      sourceFileValues.push_back(llvm::ConstantStruct::get(
+          sourceFileType,
+          {
+              // path_length=
+              llvm::ConstantInt::get(i32Type, sourceFile.path.size()),
+              // path=
+              createStringConstant(sourceFile.path, module),
+              // content_length=
+              llvm::ConstantInt::get(i32Type, sourceFile.contents.size()),
+              // content=
+              createBufferConstant(sourceFile.path, sourceFile.contents,
+                                   module),
+          }));
+    }
+    sourceFilesValue = createArrayConstant(
+        libraryName + "_sources", sourceFileType, sourceFileValues, module);
+  }
+  return llvm::ConstantStruct::get(
+      sourceTableType, {
+                           // count=
+                           llvm::ConstantInt::get(i32Type, sourceFiles.size()),
+                           // files=
+                           sourceFilesValue,
+                       });
+}
+
+llvm::Constant *LibraryBuilder::buildLibraryV0(std::string libraryName) {
+  auto &context = module->getContext();
+  auto *libraryHeaderType = makeLibraryHeaderType(context);
+  auto *libraryType = makeLibraryType(libraryHeaderType);
+  auto *i32Type = llvm::IntegerType::getInt32Ty(context);
+
+  // ----- Header -----
+
+  auto *libraryHeader = new llvm::GlobalVariable(
+      *module, libraryHeaderType, /*isConstant=*/true,
+      llvm::GlobalVariable::PrivateLinkage,
+      llvm::ConstantStruct::get(
+          libraryHeaderType,
+          {
+              // version=
+              llvm::ConstantInt::get(i32Type,
+                                     static_cast<int64_t>(Version::LATEST)),
+              // name=
+              createStringConstant(module->getName(), module),
+              // features=
+              llvm::ConstantInt::get(i32Type, static_cast<int64_t>(features)),
+              // sanitizer=
+              llvm::ConstantInt::get(i32Type,
+                                     static_cast<int64_t>(sanitizerKind)),
+          }),
+      /*Name=*/libraryName + "_header");
+  // TODO(benvanik): force alignment (8? natural pointer width?)
+
+  // ----- Library -----
+
+  auto *library = new llvm::GlobalVariable(
+      *module, libraryType, /*isConstant=*/true,
+      llvm::GlobalVariable::PrivateLinkage,
+      llvm::ConstantStruct::get(libraryType,
+                                {
+                                    // header=
+                                    libraryHeader,
+                                    // imports=
+                                    buildLibraryV0ImportTable(libraryName),
+                                    // exports=
+                                    buildLibraryV0ExportTable(libraryName),
+                                    // constants=
+                                    buildLibraryV0ConstantTable(libraryName),
+                                    // sources=
+                                    buildLibraryV0SourceTable(libraryName),
+                                }),
+      /*Name=*/libraryName);
+  // TODO(benvanik): force alignment (8? natural pointer width?)
+
+  return library;
+}
+
+} // namespace Quidditch

--- a/codegen/compiler/src/Quidditch/Target/LibraryBuilder.h
+++ b/codegen/compiler/src/Quidditch/Target/LibraryBuilder.h
@@ -1,0 +1,183 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#pragma once
+
+#include <string>
+
+#include "compiler/src/iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "llvm/IR/Module.h"
+#include "llvm/TargetParser/Triple.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace Quidditch {
+
+// Defines an `iree_hal_executable_library_v0_t` and builds the runtime metadata
+// structures and query functions.
+//
+// See iree/hal/local/executable_library.h for more information.
+//
+// Usage:
+//  LibraryBuilder builder(&module);
+//  builder.addExport(
+//     "hello", "source.mlir", 123, "test tag", DispatchAttrs{}, &helloFunc);
+//  ...
+//  auto *queryFunc = builder.build("_query_library_foo");
+//  // call queryFunc, export it, etc
+class LibraryBuilder {
+public:
+  // Builder mode setting.
+  enum class Mode : uint32_t {
+    NONE = 0u,
+    // Include entry point names and tags.
+    // If not specified then the reflection strings will be excluded to reduce
+    // binary size.
+    INCLUDE_REFLECTION_ATTRS = 1 << 0u,
+  };
+
+  // iree_hal_executable_library_version_t
+  enum class Version : uint32_t {
+    // NOTE: until we hit v1 the versioning scheme here is not set in stone.
+    // We may want to make this major release number, date codes (0x20220307),
+    // or some semantic versioning we track in whatever spec we end up having.
+    V_0_3 = 0x0000'0003u, // v0.3 - ~2022-08-08
+    V_0_4 = 0x0000'0004u, // v0.4 - ~2024-03-12
+
+    // Pinned to the latest version.
+    // Requires that the runtime be compiled with the same version.
+    LATEST = V_0_4,
+  };
+
+  // iree_hal_executable_library_features_t
+  enum class Features : uint32_t {
+    // IREE_HAL_EXECUTABLE_LIBRARY_FEATURE_NONE
+    NONE = 0u,
+  };
+
+  // iree_hal_executable_library_sanitizer_kind_t
+  enum class SanitizerKind : uint32_t {
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_NONE
+    NONE = 0u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_ADDRESS
+    ADDRESS = 1u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_MEMORY
+    MEMORY = 2u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_THREAD
+    THREAD = 3u,
+    // IREE_HAL_EXECUTABLE_LIBRARY_SANITIZER_UNDEFINED
+    UNDEFINED = 4u,
+  };
+
+  // IREE_HAL_WORKGROUP_LOCAL_MEMORY_PAGE_SIZE
+  static const int64_t kWorkgroupLocalMemoryPageSize = 4096;
+
+  // iree_hal_executable_dispatch_attrs_v0_t
+  struct DispatchAttrs {
+    // Required workgroup local memory size, in bytes.
+    int64_t localMemorySize = 0;
+
+    // True if all values are default and the attributes may be omitted.
+    constexpr bool isDefault() const { return localMemorySize == 0; }
+  };
+
+  // iree_hal_executable_source_location_v0_t
+  struct SourceLocation {
+    std::string stage;
+    std::string path;
+    uint32_t line;
+  };
+
+  LibraryBuilder(llvm::Module *module, Mode mode,
+                 Version version = Version::LATEST)
+      : module(module), mode(mode), version(version) {}
+
+  // Adds a new required feature flag bit. The runtime must support the feature
+  // for the library to be usable.
+  void addRequiredFeature(Features feature) {
+    features = static_cast<Features>(static_cast<uint32_t>(features) |
+                                     static_cast<uint32_t>(feature));
+  }
+
+  // Sets the LLVM sanitizer the executable is built to be used with. The
+  // runtime must also be compiled with the same sanitizer enabled.
+  void setSanitizerKind(SanitizerKind sanitizerKind) {
+    this->sanitizerKind = sanitizerKind;
+  }
+
+  // Defines a new runtime import function.
+  // The declared ordinal of the import matches the order they are declared.
+  void addImport(llvm::StringRef name, bool weak) {
+    imports.push_back({name.str(), weak});
+  }
+
+  // Defines a new entry point on the library implemented by |func|.
+  // |name| will be used as the library export
+  // |sourceFile| and |sourceLoc| are optional source information
+  // |tag| is an optional attachment
+  void addExport(llvm::StringRef name, SourceLocation sourceLocation,
+                 llvm::SmallVector<SourceLocation> stageLocations,
+                 llvm::StringRef tag, DispatchAttrs attrs,
+                 llvm::Function *func) {
+    exports.push_back({name.str(), std::move(sourceLocation),
+                       std::move(stageLocations), tag.str(), attrs, func});
+  }
+
+  // Defines a source file embedded in the library.
+  void addSourceFile(llvm::StringRef path, llvm::SmallVector<char> contents) {
+    sourceFiles.push_back({path.str(), std::move(contents)});
+  }
+
+  // Builds a `iree_hal_executable_library_query_fn_t` with the given
+  // |queryFuncName| that will return the current library metadata.
+  //
+  // The returned function will be inserted into the module with internal
+  // linkage. Callers may change the linkage based on their needs (such as
+  // exporting if producing a dynamic library or making dso_local for static
+  // libraries that reference the function via extern in another compilation
+  // unit, etc).
+  llvm::Function *build(llvm::StringRef queryFuncName);
+
+private:
+  // Builds and returns an iree_hal_executable_library_v0_t global constant.
+  llvm::Constant *buildLibraryV0(std::string libraryName);
+  llvm::Constant *buildLibraryV0ImportTable(std::string libraryName);
+  llvm::Constant *buildLibraryV0ExportTable(std::string libraryName);
+  llvm::Constant *buildLibraryV0ConstantTable(std::string libraryName);
+  llvm::Constant *buildLibraryV0SourceTable(std::string libraryName);
+
+  llvm::Module *module = nullptr;
+  Mode mode = Mode::INCLUDE_REFLECTION_ATTRS;
+  Version version = Version::LATEST;
+  Features features = Features::NONE;
+  SanitizerKind sanitizerKind = SanitizerKind::NONE;
+
+  struct Import {
+    std::string symbol_name;
+    bool weak = false;
+  };
+  llvm::SmallVector<Import> imports;
+
+  struct Dispatch {
+    std::string name;
+    SourceLocation sourceLocation;
+    llvm::SmallVector<SourceLocation> stageLocations;
+    std::string tag;
+    DispatchAttrs attrs;
+    llvm::Function *func;
+  };
+  std::vector<Dispatch> exports;
+
+  size_t constantCount = 0;
+
+  struct SourceFile {
+    std::string path;
+    llvm::SmallVector<char> contents;
+  };
+  llvm::SmallVector<SourceFile> sourceFiles;
+};
+
+} // namespace Quidditch

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -26,7 +26,6 @@
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
 #include "Quidditch/Dialect/Snitch/Transforms/Passes.h"
 
-#include "compiler/plugins/target/LLVMCPU/LibraryBuilder.h"
 #include "compiler/plugins/target/LLVMCPU/LinkerTool.h"
 #include "compiler/plugins/target/LLVMCPU/StaticLibraryGenerator.h"
 
@@ -40,6 +39,7 @@
 #include "llvm/Support/FileUtilities.h"
 #include "llvm/Support/Program.h"
 
+#include "LibraryBuilder.h"
 #include "Passes.h"
 
 using namespace mlir;
@@ -328,9 +328,9 @@ public:
       return nullptr;
     }
 
-    IREE::HAL::LibraryBuilder libraryBuilder(
-        llvmModule.get(), IREE::HAL::LibraryBuilder::Mode::NONE,
-        IREE::HAL::LibraryBuilder::Version::LATEST);
+    Quidditch::LibraryBuilder libraryBuilder(
+        llvmModule.get(), Quidditch::LibraryBuilder::Mode::NONE,
+        Quidditch::LibraryBuilder::Version::LATEST);
     auto align16 = llvm::Attribute::getWithAlignment(context, llvm::Align(16));
     for (auto exportOp :
          variantOp.getBlock().getOps<IREE::HAL::ExecutableExportOp>()) {
@@ -360,12 +360,12 @@ public:
                                     .value_or(APInt(64, 0))
                                     .getSExtValue();
 
-      IREE::HAL::LibraryBuilder::SourceLocation sourceLocation;
-      SmallVector<IREE::HAL::LibraryBuilder::SourceLocation> stageLocations;
+      Quidditch::LibraryBuilder::SourceLocation sourceLocation;
+      SmallVector<Quidditch::LibraryBuilder::SourceLocation> stageLocations;
       libraryBuilder.addExport(
           exportOp.getName(), std::move(sourceLocation),
           std::move(stageLocations), /*tag=*/"",
-          IREE::HAL::LibraryBuilder::DispatchAttrs{localMemorySize}, llvmFunc);
+          Quidditch::LibraryBuilder::DispatchAttrs{localMemorySize}, llvmFunc);
     }
     auto *queryLibraryFunc =
         libraryBuilder.build("quidditch_" + libraryName + "_library_query");


### PR DESCRIPTION
We want to change the format used to represent an executable. This commit does nothing but fork it to have later diffs show the difference.