### PR TITLE
[quidditch_snitch] Implement barrier operation

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -121,4 +121,10 @@ def QuidditchSnitch_L1MemoryViewOp : QuidditchSnitch_Op<"l1_memory_view",
   }];
 }
 
+def QuidditchSnitch_BarrierOp : QuidditchSnitch_Op<"barrier"> {
+  let assemblyFormat = [{
+    attr-dict
+  }];
+}
+
 #endif

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/barrier.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/barrier.mlir
@@ -1,0 +1,8 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test() {
+  // CHECK: call @snrt_cluster_hw_barrier()
+  quidditch_snitch.barrier
+  return
+}


### PR DESCRIPTION
This operation is used to sync up all cores within a cluster effiecently. We mostly want to use it in DMA and compute core codegen to communicate phases being done which are usually compute and copy phases