### PR TITLE
[quidditch_snitch] Basic implementations of DMA operations

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/CMakeLists.txt
@@ -13,14 +13,18 @@ iree_cc_library(
         "QuidditchSnitchDialect.h.inc"
         "QuidditchSnitchOps.cpp.inc"
         "QuidditchSnitchOps.h.inc"
+        "QuidditchSnitchTypes.cpp.inc"
+        "QuidditchSnitchTypes.h.inc"
         SRCS
         "QuidditchSnitchAttrs.cpp"
         "QuidditchSnitchDialect.cpp"
         "QuidditchSnitchOps.cpp"
+        "QuidditchSnitchTypes.cpp"
         DEPS
         ::QuidditchSnitchAttrsGen
         ::QuidditchSnitchDialectGen
         ::QuidditchSnitchOpsGen
+        ::QuidditchSnitchTypesGen
         LLVMSupport
         MLIRIR
         MLIRInferTypeOpInterface
@@ -48,7 +52,6 @@ iree_tablegen_library(
         --gen-dialect-defs QuidditchSnitchDialect.cpp.inc
 )
 
-
 iree_tablegen_library(
         NAME
         QuidditchSnitchAttrsGen
@@ -57,4 +60,14 @@ iree_tablegen_library(
         OUTS
         --gen-attrdef-decls QuidditchSnitchAttrs.h.inc
         --gen-attrdef-defs QuidditchSnitchAttrs.cpp.inc
+)
+
+iree_tablegen_library(
+        NAME
+        QuidditchSnitchTypesGen
+        TD_FILE
+        "QuidditchSnitchTypes.td"
+        OUTS
+        --gen-typedef-decls QuidditchSnitchTypes.h.inc
+        --gen-typedef-defs QuidditchSnitchTypes.cpp.inc
 )

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
@@ -2,6 +2,7 @@
 
 #include "QuidditchSnitchAttrs.h"
 #include "QuidditchSnitchOps.h"
+#include "QuidditchSnitchTypes.h"
 
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp.inc"
 
@@ -15,5 +16,9 @@ void QuidditchSnitchDialect::initialize() {
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.cpp.inc"
       >();
 }

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td
@@ -13,6 +13,7 @@ def QuidditchSnitch_Dialect : Dialect {
   );
 
   let useDefaultAttributePrinterParser = 1;
+  let useDefaultTypePrinterParser = 1;
 }
 
 #endif

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h
@@ -9,5 +9,7 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 
+#include "QuidditchSnitchTypes.h"
+
 #define GET_OP_CLASSES
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h.inc"

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -2,6 +2,7 @@
 #define QUIDDITCH_DIALECT_SNITCH_QUIDDITCHSNITCHOPS
 
 include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td"
+include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.td"
 include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td"
 include "mlir/IR/CommonTypeConstraints.td"
 include "mlir/IR/OpBase.td"
@@ -118,6 +119,51 @@ def QuidditchSnitch_L1MemoryViewOp : QuidditchSnitch_Op<"l1_memory_view",
 
   let assemblyFormat = [{
     `->` type($result) attr-dict
+  }];
+}
+
+def QuidditchSnitch_StartDMATransferOp : QuidditchSnitch_Op<"start_dma_transfer",
+  [MemoryEffects<[MemWrite]>, SameOperandsElementType, SameOperandsShape]> {
+
+  let description = [{
+    Operation performing a DMA transfer from one MemRef to another.
+    At least one of the two MemRefs must be in L1 memory.
+    The shapes (including dynamic ones at runtime) of both MemRefs must be
+    identical with different strides and offsets allowed.
+
+    The DMA operation is likely (but not guaranteed) to run asynchronous and
+    its completion only guaranteed by executing the `wait_for_dma_transfers`
+    operation with the token returned by this operation or a later one.
+  }];
+
+  // TODO: In reality what the constraint here is, is that both of them must either be contiguous or if a dimension is
+  //       not contiguous in one of them, all dimensions prior to that must be contiguous (i.e. of equal size).
+  //       Can support higher dimensions and funkier strides once needed.
+  let arguments = (ins
+    Arg<MemRefRankOf<[AnyType], [1, 2]>, "source", [MemRead]>:$source,
+    Arg<MemRefRankOf<[AnyType], [1, 2]>, "destination", [MemWrite]>:$dest
+  );
+
+  let results = (outs QuidditchSnitch_DMATokenType:$token);
+
+  let assemblyFormat = [{
+    `from` $source `:` type($source) `to` $dest `:` type($dest) attr-dict
+  }];
+}
+
+def QuidditchSnitch_WaitForDMATransfersOp
+  : QuidditchSnitch_Op<"wait_for_dma_transfers"> {
+
+  let description = [{
+    Operation awaiting for DMA transfers denoted by its tokens to be finished.
+  }];
+
+  let arguments = (ins
+    Variadic<QuidditchSnitch_DMATokenType>:$tokens
+  );
+
+  let assemblyFormat = [{
+    $tokens `:` type($tokens) attr-dict
   }];
 }
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.cpp
@@ -1,0 +1,11 @@
+#include "QuidditchSnitchTypes.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
+
+#include "QuidditchSnitchDialect.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.cpp.inc"

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.h
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.h
@@ -1,0 +1,7 @@
+
+#pragma once
+
+#include "mlir/IR/Types.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.h.inc"

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.td
@@ -1,0 +1,18 @@
+#ifndef QUIDDITCH_DIALECT_SNITCH_QUIDDITCHSNITCHTYPES
+#define QUIDDITCH_DIALECT_SNITCH_QUIDDITCHSNITCHTYPES
+
+include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td"
+include "mlir/IR/AttrTypeBase.td"
+
+class QuidditchSnitch_Type<string name, list<Trait> traits = []> :
+  TypeDef<QuidditchSnitch_Dialect, name, traits>;
+
+def QuidditchSnitch_DMATokenType : QuidditchSnitch_Type<"DMAToken"> {
+  let mnemonic = "dma_token";
+
+  let description = [{
+    Type representing a potentially active DMA transfer.
+  }];
+}
+
+#endif

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer_1d.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer_1d.mlir
@@ -1,0 +1,15 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) -> !quidditch_snitch.dma_token {
+  // CHECK: %[[ARG0_PTR:.*]] = llvm.extractvalue %{{.*}}[1]
+  // CHECK: %[[ARG1_PTR:.*]] = llvm.extractvalue %{{.*}}[1]
+  // CHECK: %[[ARG0_SIZE:.*]] = llvm.extractvalue %{{.*}}[3, 0]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %{{.*}}[%[[ARG0_SIZE]]]
+  // CHECK: %[[SIZE:.*]] = llvm.ptrtoint %[[GEP]]
+  // CHECK: %[[R:.*]] = llvm.call @snrt_dma_start_1d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[SIZE]])
+  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?xf32> to %arg1 : memref<?xf32>
+  // CHECK: %[[C:.*]] = builtin.unrealized_conversion_cast %[[R]]
+  // CHECK: return %[[C]]
+  return %0 : !quidditch_snitch.dma_token
+}

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_wait.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_wait.mlir
@@ -1,0 +1,9 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test(%arg0 : !quidditch_snitch.dma_token) {
+  // TODO: This should be a call to snrt_dma_wait but is currently bugged.
+  // CHECK: call @snrt_dma_wait_all()
+  quidditch_snitch.wait_for_dma_transfers %arg0 : !quidditch_snitch.dma_token
+  return
+}


### PR DESCRIPTION
This PR implements DMA copy and wait operations. Snitch's DMA is asnychronous and has special hardware support for faster transfers between L1 and L3 than doing it manually. The currentl lowering to LLVM simple performs calls into the snitch runtime for convenience with the idea of these being later inlined via LTO once implemented.

Noteworthy is that the support for various memref shapes, strides and dimension is currently very limited but enough for what IREE generates.