### PR TITLE
[SnitchToLLVM] Properly detect contiguous MemRefs

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -125,8 +125,13 @@ struct StartDMATransferOp1DLowering
     SmallVector<Value> sizes;
     SmallVector<Value> strides;
     Value totalSize;
-    getMemRefDescriptorSizes(op->getLoc(), op.getSource().getType(),
-                             dynamicSizes, rewriter, sizes, strides, totalSize);
+    getMemRefDescriptorSizes(
+        op->getLoc(),
+        // Offsets are not considered an identity layout.
+        // Get rid of the layout entirely for the size calculation.
+        MemRefType::get(sourceMemRef.getShape(), sourceMemRef.getElementType(),
+                        nullptr, sourceMemRef.getMemorySpace()),
+        dynamicSizes, rewriter, sizes, strides, totalSize);
 
     rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, dmaStart1DFunc,
                                               ValueRange{

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer_1d.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer_1d.mlir
@@ -18,6 +18,8 @@ func.func @test(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) -> !quidditch_snit
 func.func @test2(%arg0 : memref<?xf32>, %arg1 : memref<?xf32, strided<[1], offset: ?>>) -> !quidditch_snitch.dma_token {
   // CHECK: llvm.call @snrt_dma_start_1d(
   %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?xf32> to %arg1 : memref<?xf32, strided<[1], offset: ?>>
+  // CHECK: llvm.call @snrt_dma_start_1d(
+  %1 = quidditch_snitch.start_dma_transfer from %arg1 : memref<?xf32, strided<[1], offset: ?>> to %arg0 : memref<?xf32>
   return %0 : !quidditch_snitch.dma_token
 }
 
@@ -27,3 +29,4 @@ func.func @test3(%arg0 : memref<?x4xf32>, %arg1 : memref<?x4xf32, strided<[4, 1]
   %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?x4xf32> to %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>
   return %0 : !quidditch_snitch.dma_token
 }
+

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer_1d.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer_1d.mlir
@@ -13,3 +13,17 @@ func.func @test(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) -> !quidditch_snit
   // CHECK: return %[[C]]
   return %0 : !quidditch_snitch.dma_token
 }
+
+// CHECK-LABEL: @test2
+func.func @test2(%arg0 : memref<?xf32>, %arg1 : memref<?xf32, strided<[1], offset: ?>>) -> !quidditch_snitch.dma_token {
+  // CHECK: llvm.call @snrt_dma_start_1d(
+  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?xf32> to %arg1 : memref<?xf32, strided<[1], offset: ?>>
+  return %0 : !quidditch_snitch.dma_token
+}
+
+// CHECK-LABEL: @test3
+func.func @test3(%arg0 : memref<?x4xf32>, %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>) -> !quidditch_snitch.dma_token {
+  // CHECK: llvm.call @snrt_dma_start_1d(
+  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?x4xf32> to %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>
+  return %0 : !quidditch_snitch.dma_token
+}


### PR DESCRIPTION
Contiguous MemRefs can be copied using just `snrt_dma_start_1d` which simplifies some of the required setup for the DMA. This PR properly implements the detection of such contiguous MemRefs by first checking for an identity layout and otherwise, checking if the sided layout describes an identity layout in all but offset.