### PR TITLE
[quidditch_snitch] Allow dynamic dims in and simplify `copy_l1_tensor`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -82,29 +82,29 @@ def QuidditchSnitch_MemRefMicrokernelOp
   }];
 }
 
-def QuidditchSnitch_CopyL1TensorOp : QuidditchSnitch_Op<"copy_l1_tensor",
+def QuidditchSnitch_CopyTensorOp : QuidditchSnitch_Op<"copy_tensor",
   [SameOperandsAndResultType, NoMemoryEffect,
    DeclareOpInterfaceMethods<BufferizableOpInterface,
     ["resultBufferizesToMemoryWrite", "bufferizesToMemoryRead",
      "bufferizesToMemoryWrite", "getAliasingValues", "getBufferType",
-      "bufferize"]>]> {
+      "bufferize", "bufferizesToAllocation"]>]> {
 
   let description = [{
-    Operation performing copies of tensors between memory spaces.
-    If `$transfer_to_l1` is true, then the op ensures that the resulting tensor
-    is in L1.
+    Operation performing a copy of a tensor to another memory spaces.
+    If `$transfers_to_l1` is true, then the op ensures that the resulting
+    tensor is in L1 memory.
     Otherwise, the output tensor is guaranteed to be in L3 memory.
     This operation is a noop if `$copy` and `$result` are already in the same
-    memory space.
+    memory space and bufferization can elide the copy.
   }];
 
   // TODO: Not a big fan of the UnitAttr. This should be an enum.
-  let arguments = (ins AnyStaticShapeTensor:$copy, UnitAttr:$transfer_to_l1);
+  let arguments = (ins AnyRankedTensor:$copy, UnitAttr:$transfers_to_l1);
 
-  let results = (outs AnyStaticShapeTensor:$result);
+  let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $copy `to` ( `L1` $transfer_to_l1^) : (`L3`)? `:` type($copy) attr-dict
+    $copy `to` ( `L1` $transfers_to_l1^) : (`L3`)? `:` type($copy) attr-dict
   }];
 
   let hasFolder = 1;

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PromoteToL1.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PromoteToL1.cpp
@@ -32,7 +32,7 @@ void PromoteToL1::runOnOperation() {
     }
 
     OpBuilder builder(tensorOp);
-    Value replacement = builder.create<CopyL1TensorOp>(
+    Value replacement = builder.create<CopyTensorOp>(
         tensorOp.getLoc(), tensorOp, /*transfers_to_l1=*/true);
     tensorOp.replaceAllUsesWith(replacement);
     tensorOp.erase();
@@ -53,9 +53,9 @@ void PromoteToL1::runOnOperation() {
     // Create copies into L1 for all tensors used in the kernel.
     auto builder = OpBuilder(microkernelOp);
     for (TypedValue<RankedTensorType> value : nonL1Uses) {
-      auto copyOp = builder.create<CopyL1TensorOp>(microkernelOp.getLoc(),
-                                                   /*copy=*/value,
-                                                   /*transfers_to_l1=*/true);
+      auto copyOp = builder.create<CopyTensorOp>(microkernelOp.getLoc(),
+                                                 /*copy=*/value,
+                                                 /*transfers_to_l1=*/true);
       value.replaceUsesWithIf(copyOp, [&](OpOperand &operand) {
         return microkernelOp.getBody().isAncestor(
             operand.getOwner()->getParentRegion());

--- a/codegen/tests/Dialect/Snitch/IR/bufferization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/bufferization.mlir
@@ -30,7 +30,7 @@ func.func @copy_l1_buffer(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
   // CHECK-SAME: : memref<32xf32, #quidditch_snitch.l1_encoding>
   // CHECK: memref.copy %[[ARG0]], %[[ALLOC]]
   // CHECK: %[[R:.*]] = bufferization.to_tensor %[[ALLOC]]
-  %r = quidditch_snitch.copy_l1_tensor %arg0 to L1 : tensor<32xf32>
+  %r = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<32xf32>
   // CHECK: return %[[R]]
   return %r : tensor<32xf32>
 }
@@ -39,8 +39,8 @@ func.func @copy_l1_buffer(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
 func.func @copy_l1_buffer_elided(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
   // CHECK: memref.alloc()
   // CHECK-NOT: memref.alloc()
-  %r = quidditch_snitch.copy_l1_tensor %arg0 to L1 : tensor<32xf32>
-  %r2 = quidditch_snitch.copy_l1_tensor %r to L1 : tensor<32xf32>
+  %r = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<32xf32>
+  %r2 = quidditch_snitch.copy_tensor %r to L1 : tensor<32xf32>
   // CHECK: return
   return %r2 : tensor<32xf32>
 }
@@ -50,7 +50,7 @@ func.func @copy_l1_buffer_alloca_elided() -> tensor<32xf32> {
   // CHECK: memref.alloc()
   // CHECK-NOT: memref.alloc()
   %r = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding} : tensor<32xf32>
-  %r2 = quidditch_snitch.copy_l1_tensor %r to L1 : tensor<32xf32>
+  %r2 = quidditch_snitch.copy_tensor %r to L1 : tensor<32xf32>
   // CHECK: return
   return %r2 : tensor<32xf32>
 }

--- a/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
@@ -62,9 +62,9 @@ func.func @identical_argument(%arg0 : i32) -> i32 {
 // CHECK-LABEL: @double_copy
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 func.func @double_copy(%arg0 : tensor<32xf64>) -> tensor<32xf64> {
-  // CHECK-NEXT: %[[R:.*]] = quidditch_snitch.copy_l1_tensor %[[ARG0]] to L1
-  %0 = quidditch_snitch.copy_l1_tensor %arg0 to L3 : tensor<32xf64>
-  %1 = quidditch_snitch.copy_l1_tensor %0 to L1 : tensor<32xf64>
+  // CHECK-NEXT: %[[R:.*]] = quidditch_snitch.copy_tensor %[[ARG0]] to L1
+  %0 = quidditch_snitch.copy_tensor %arg0 to L3 : tensor<32xf64>
+  %1 = quidditch_snitch.copy_tensor %0 to L1 : tensor<32xf64>
   // CHECK-NEXT: return %[[R]]
   return %1 : tensor<32xf64>
 }

--- a/codegen/tests/Dialect/Snitch/IR/roundtrip.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/roundtrip.mlir
@@ -14,3 +14,8 @@ func.func @test2(%arg0 : tensor<f64>) {
   }
   return
 }
+
+func.func @test3(%arg0 : tensor<?x4xf64>) -> tensor<?x4xf64> {
+  %0 = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<?x4xf64>
+  return %0 : tensor<?x4xf64>
+}

--- a/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-to-l1.mlir
@@ -6,9 +6,9 @@
 func.func @test(%a : tensor<32x32xf32>, %b : tensor<32x32xf32>) -> tensor<32x32xf32> {
   // CHECK: %[[E:.*]] = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding}
   %e = bufferization.alloc_tensor() : tensor<32x32xf32>
-  // CHECK: %[[A2:.*]] = quidditch_snitch.copy_l1_tensor %[[A]] to L1
-  // CHECK: %[[B2:.*]] = quidditch_snitch.copy_l1_tensor %[[B]] to L1
-  // CHECK: %[[E2:.*]] = quidditch_snitch.copy_l1_tensor %[[E]] to L1
+  // CHECK: %[[A2:.*]] = quidditch_snitch.copy_tensor %[[A]] to L1
+  // CHECK: %[[B2:.*]] = quidditch_snitch.copy_tensor %[[B]] to L1
+  // CHECK: %[[E2:.*]] = quidditch_snitch.copy_tensor %[[E]] to L1
   // CHECK: %[[R:.*]] = quidditch_snitch.tensor.microkernel
   %r = quidditch_snitch.tensor.microkernel -> tensor<32x32xf32> {
     // CHECK: linalg.matmul ins(%[[A2]], %[[B2]] : {{.*}}) outs(%[[E2]] : {{.*}})


### PR DESCRIPTION
There is no fundamental reasons why it only allowed static shapes. While touching the op, also rename it to `copy_tensor` and simplify its bufferization logic a bit. Should be NFC.

Note that bufferization of dynamic dim tensors is not yet implemented and require more changes