### PR TITLE
[compiler] Satisfy invariant of `hal.executable.export`

### DIFF
--- a/codegen/compiler/src/Quidditch/Target/FormMicrokernels.cpp
+++ b/codegen/compiler/src/Quidditch/Target/FormMicrokernels.cpp
@@ -65,10 +65,6 @@ static void outlineOpsToFunction(MutableArrayRef<linalg::LinalgOp> ops) {
 void FormMicrokernels::runOnOperation() {
   FunctionOpInterface func = getOperation();
 
-  // We add this suffix for tooling to know whether the kernel was xDSL
-  // compiled. It should have as little semantic impact as possible.
-  func.setName((func.getName() + "$iree_to_xdsl").str());
-
   SmallVector<linalg::LinalgOp> outlinedOps;
   func.walk([&](Block *block) {
     for (Operation &op : *block) {


### PR DESCRIPTION
`hal.executable.export` has the (reasonable) invariant of the symbol that is being exported referring to the function that serves as the kernel entry point. We previously broke this invariant by renaming the entrypoint. This PR moves the renaming to very late in the pipeline in LLVM IR to uphold the invariant while in MLIR. A side-effect of this change is that we completely stop depending on the name of the function having any significance on semantics.