### PR TITLE
[ConvertToRISCV] Fix performance regression due to missing `fmadd`

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertToRISCV.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertToRISCV.cpp
@@ -107,6 +107,7 @@ ConvertToRISCV::convertToRISCVAssembly(MemRefMicrokernelOp kernelOp,
   int ret = llvm::sys::ExecuteAndWait(
       xDSLOptPath,
       {xDSLOptPath, "-p",
+       "arith-add-fastmath,"
        "convert-linalg-to-memref-stream,"
        "test-optimise-memref-stream," // NOLINT(*-suspicious-missing-comma)
        "test-lower-memref-stream-to-snitch-stream,"


### PR DESCRIPTION
This caused a 20% performance regression in NsNet2