### PR TITLE
[quidditch_snitch] Add `completed_token` op

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -103,6 +103,8 @@ def QuidditchSnitch_StartDMATransferOp : QuidditchSnitch_Op<"start_dma_transfer"
   let assemblyFormat = [{
     `from` $source `:` type($source) `to` $dest `:` type($dest) attr-dict
   }];
+
+  let hasCanonicalizeMethod = 1;
 }
 
 def QuidditchSnitch_WaitForDMATransfersOp
@@ -118,6 +120,24 @@ def QuidditchSnitch_WaitForDMATransfersOp
 
   let assemblyFormat = [{
     $tokens `:` type($tokens) attr-dict
+  }];
+
+  let hasFolder = 1;
+  let hasCanonicalizeMethod = 1;
+}
+
+def QuidditchSnitch_CompletedTokenOp
+  : QuidditchSnitch_Op<"completed_token", [Pure]> {
+
+  let description = [{
+    Op returning a special value representing a completed DMA transfer.
+    Passing this token to `wait_for_dma_transfers` will always return immediately.
+  }];
+
+  let results = (outs QuidditchSnitch_DMATokenType:$token);
+
+  let assemblyFormat = [{
+    attr-dict
   }];
 }
 

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/completed_token.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/completed_token.mlir
@@ -1,0 +1,10 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test() -> !quidditch_snitch.dma_token {
+  // CHECK: %[[T:.*]] = llvm.mlir.constant(0 : {{.*}})
+  // CHECK: %[[C:.*]] = builtin.unrealized_conversion_cast %[[T]]
+  // CHECK: return %[[C]]
+  %0 = quidditch_snitch.completed_token
+  return %0 : !quidditch_snitch.dma_token
+}

--- a/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
@@ -45,3 +45,20 @@ func.func @double_copy(%arg0 : tensor<32xf64>) -> tensor<32xf64> {
   // CHECK-NEXT: return %[[R]]
   return %1 : tensor<32xf64>
 }
+
+
+// CHECK-LABEL: @wait_gets_removed
+func.func @wait_gets_removed() {
+  // CHECK-NEXT: return
+  %0 = quidditch_snitch.completed_token
+  quidditch_snitch.wait_for_dma_transfers %0 : !quidditch_snitch.dma_token
+  return
+}
+
+// CHECK-LABEL: @noop_transfer
+func.func @noop_transfer(%arg0 : memref<?xf32>) -> !quidditch_snitch.dma_token {
+  // CHECK-NEXT: %[[R:.*]] = quidditch_snitch.completed_token
+  // CHECK-NEXT: return %[[R]]
+  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?xf32> to %arg0 : memref<?xf32>
+  return %0 : !quidditch_snitch.dma_token
+}


### PR DESCRIPTION
This op represents a completed DMA transfer. The main use-case is for canonicalization compositon. Folding a `start_dma_transfer` op to this value allows trivially removing a `wait_for_dma_transfers` op afterwards.