### PR TITLE
[quidditch_snitch] Add `call_microkernel` op

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -36,6 +36,28 @@ def QuidditchSnitch_MemRefMicrokernelOp
   }];
 }
 
+def QuidditchSnitch_CallMicrokernelOp
+  : QuidditchSnitch_Op<"call_microkernel"> {
+
+  let description = [{
+
+  }];
+
+  let arguments = (ins StrAttr:$name, Variadic<AnyType>:$inputs, StrAttr:$riscv_assembly);
+
+  let assemblyFormat = [{
+    $name `(` $inputs `)` (`:` type($inputs)^)? `[``{`
+    custom<RISCVAssembly>($riscv_assembly)
+    `}` `]` attr-dict
+  }];
+
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    static bool supportsArgumentType(mlir::Type type);
+  }];
+}
+
 def QuidditchSnitch_CopyTensorOp : QuidditchSnitch_Op<"copy_tensor",
   [SameOperandsAndResultType, NoMemoryEffect,
    DeclareOpInterfaceMethods<BufferizableOpInterface,

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/microkernel_call.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/microkernel_call.mlir
@@ -1,0 +1,18 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test(%arg0 : memref<32xi8, strided<[1], offset: ?>>) {
+  // CHECK: %[[ARG0:.*]] = builtin.unrealized_conversion_cast
+  // CHECK: %[[ALIGN_PTR:.*]] = llvm.extractvalue %[[ARG0]][1]
+  // CHECK: %[[OFFSET:.*]] = llvm.extractvalue %[[ARG0]][2]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[ALIGN_PTR]][%[[OFFSET]]]
+  // CHECK: llvm.call @name(%[[GEP]])
+  quidditch_snitch.call_microkernel "name"(%arg0) : memref<32xi8, strided<[1], offset: ?>> [{
+    "the assembly"
+  }]
+  return
+}
+
+// CHECK: llvm.func @name(!llvm.ptr)
+// CHECK-SAME: hal.import.bitcode
+// CHECK-SAME: quidditch_snitch.riscv_assembly = "the assembly"


### PR DESCRIPTION
The op serves two purposes:
* Representing xDSL compiled RISC-V output in our IR that must be called later
* Implementing the custom calling convention that we implement with xDSL kernels

In particular, we always pass the buffer pointer to xDSL, not the aligned pointer.