### PR TITLE
[ConvertToRISCV] Do not provide MemRef offset to xDSL

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -257,8 +257,12 @@ struct CallMicrokernelOpLowering : ConvertOpToLLVMPattern<CallMicrokernelOp> {
               memRefType.getShape(), memRefType.getElementType(),
               /*layout=*/nullptr, memRefType.getMemorySpace());
         }
-        types.push_back(getTypeConverter()->convertCallingConventionType(
-            type, /*useBarePointerCallConv=*/true));
+        Type converted = getTypeConverter()->convertCallingConventionType(
+            type, /*useBarePointerCallConv=*/true);
+        if (!converted)
+          return failure();
+
+        types.push_back(converted);
       }
 
       kernelDecl = rewriter.create<LLVM::LLVMFuncOp>(


### PR DESCRIPTION
Since we always pass the offset pointer, having xDSL also apply an offset is incorrect. Similarly, we want to pretend that there is no offset when a dynamic offset is present.