### PR TITLE
[compiler][runtime] Implement distributing `forall` to all compute cores

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -169,4 +169,14 @@ def QuidditchSnitch_BarrierOp : QuidditchSnitch_Op<"barrier"> {
   }];
 }
 
+def QuidditchSnitch_ClusterIndexOp
+  : QuidditchSnitch_Op<"cluster_index", [Pure]> {
+
+  let results = (outs Index:$result);
+
+  let assemblyFormat = [{
+    attr-dict
+  }];
+}
+
 #endif

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
@@ -15,8 +15,9 @@ iree_cc_library(
         "Passes.h.inc"
         SRCS
         "FormMicrokernels.cpp"
-        "PromoteToL1.cpp"
+        "LowerForallOp.cpp"
         "LowerL1Allocations.cpp"
+        "PromoteToL1.cpp"
         "SpecializeDMACode.cpp"
         DEPS
         ::PassesIncGen
@@ -24,4 +25,5 @@ iree_cc_library(
         MLIRIR
         MLIRLinalgDialect
         MLIRBufferizationDialect
+        iree::compiler::Dialect::HAL::IR
 )

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerForallOp.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerForallOp.cpp
@@ -1,0 +1,66 @@
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
+
+namespace quidditch::Snitch {
+#define GEN_PASS_DEF_LOWERFORALLOPPASS
+#include "Quidditch/Dialect/Snitch/Transforms/Passes.h.inc"
+} // namespace quidditch::Snitch
+
+namespace {
+class LowerForallOp
+    : public quidditch::Snitch::impl::LowerForallOpPassBase<LowerForallOp> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+using namespace quidditch::Snitch;
+
+void LowerForallOp::runOnOperation() {
+  getOperation()->walk([&](scf::ForallOp forallOp) {
+    std::optional<IntegerAttr> attr = getConfigIntegerAttr(
+        IREE::HAL::ExecutableTargetAttr::lookup(forallOp), "compute_cores");
+    if (!attr)
+      return;
+
+    // Nothing else supported right now.
+    if (forallOp.getInductionVars().size() != 1)
+      return;
+
+    // No longer needed in any of the below code.
+    forallOp.getTerminator().erase();
+
+    OpBuilder builder(forallOp);
+    Value id = builder.create<ClusterIndexOp>(forallOp.getLoc());
+
+    Value lb = forallOp.getLowerBound(builder).front();
+    Value ub = forallOp.getUpperBound(builder).front();
+    Value step = forallOp.getStep(builder).front();
+    lb = builder.create<arith::AddIOp>(
+        forallOp.getLoc(), lb,
+        builder.create<arith::MulIOp>(forallOp.getLoc(), id, step));
+    Value cores = builder.create<arith::ConstantIndexOp>(
+        forallOp.getLoc(), attr->getValue().getZExtValue());
+    step = builder.create<arith::MulIOp>(forallOp.getLoc(), step, cores);
+    auto forOp = builder.create<scf::ForOp>(forallOp.getLoc(), lb, ub, step);
+
+    forOp.getRegion().takeBody(forallOp.getRegion());
+    builder.setInsertionPointToEnd(forOp.getBody());
+    builder.create<scf::YieldOp>(forallOp.getLoc());
+
+    forallOp.erase();
+  });
+}

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
@@ -61,4 +61,10 @@ def SpecializeDMACodePass : Pass<"quidditch-specialize-dma-code",
   }];
 }
 
+def LowerForallOpPass : Pass<"quidditch-lower-forall-op"> {
+  let dependentDialects = [
+    "quidditch::Snitch::QuidditchSnitchDialect",
+  ];
+}
+
 #endif

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -221,7 +221,7 @@ public:
     addIREEPostBufferizationPasses(modulePassManager.nest<func::FuncOp>());
 
     FunctionLikeNest(modulePassManager)
-        .addPass(createForallToForLoopPass)
+        .addPass(quidditch::Snitch::createLowerForallOpPass)
         // TODO: Remove the following pass and plumb support for
         // #hal.descriptor_type memory space through the stack.
         .addPass(createEraseHALDescriptorTypeFromMemRefPass)
@@ -231,6 +231,8 @@ public:
         })
         .addPass(quidditch::createReluToMaxPass)
         .addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
+        .addPass(createLoopInvariantCodeMotionPass)
         .addPass(createLinalgGeneralizeNamedOpsPass)
         .addPass(createRemoveSingleIterationLoopPass)
         .addPass(quidditch::Snitch::createFormMicrokernelsPass);

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/cluster_index.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/cluster_index.mlir
@@ -1,0 +1,8 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test() -> index {
+  // CHECK: call @snrt_cluster_core_idx()
+  %0 = quidditch_snitch.cluster_index
+  return %0 : index
+}

--- a/codegen/tests/Dialect/Snitch/Transforms/lower-forall.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/lower-forall.mlir
@@ -1,0 +1,27 @@
+// RUN: quidditch-opt %s -p "builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(quidditch-lower-forall-op)))))" -allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: @test
+hal.executable @test {
+  // CHECK-LABEL: hal.executable.variant public @static
+  hal.executable.variant @static target(#hal.executable.target<"", "", {compute_cores = 8 : i32}>) {
+    builtin.module {
+      // CHECK-LABEL: func @test
+      // CHECK-SAME: %[[LB:[[:alnum:]]+]]
+      // CHECK-SAME: %[[UB:[[:alnum:]]+]]
+      // CHECK-SAME: %[[STEP:[[:alnum:]]+]]
+      func.func @test(%lb : index, %ub : index, %step : index) {
+        // CHECK: %[[ID:.*]] = quidditch_snitch.cluster_index
+        // CHECK: %[[LB2:.*]] = arith.muli %[[ID]], %[[STEP]]
+        // CHECK: %[[LB3:.*]] = arith.addi %[[LB]], %[[LB2]]
+        // CHECK: %[[CORES:.*]] = arith.constant 8
+        // CHECK: %[[STEP2:.*]] = arith.muli %[[STEP]], %[[CORES]]
+        // CHECK: scf.for %[[IV:.*]] = %[[LB3]] to %[[UB]] step %[[STEP2]]
+        scf.forall (%iter) = (%lb) to (%ub) step (%step) {
+          // CHECK-NEXT: "test.op"(%[[IV]])
+          "test.op"(%iter) : (index) -> ()
+        }
+        return
+      }
+    }
+  }
+}

--- a/runtime/runtime/src/Quidditch/dispatch/dispatch.h
+++ b/runtime/runtime/src/Quidditch/dispatch/dispatch.h
@@ -33,6 +33,12 @@ void quidditch_dispatch_set_kernel(
 void quidditch_dispatch_queue_workgroup(
     const iree_hal_executable_workgroup_state_v0_t* workgroup_state);
 
+/// Queues a workgroup on all compute cores with the last configured kernel and
+/// dispatch state and immediately starts executing the kernel on all compute
+/// cores.
+void quidditch_dispatch_queue_subgroups(
+    const iree_hal_executable_workgroup_state_v0_t* workgroup_state);
+
 /// Executes all queued workgroups and waits for them to finish.
 void quidditch_dispatch_execute_workgroups();
 

--- a/runtime/runtime/src/Quidditch/executable/executable.c
+++ b/runtime/runtime/src/Quidditch/executable/executable.c
@@ -229,7 +229,6 @@ iree_status_t quidditch_executable_issue_dispatch_inline(
   } else {
     // Snitch distributes workgroups to clusters.
     // I.e., one workgroup runs on one cluster.
-    // TODO: Subgroup distribution.
     iree_hal_executable_dispatch_v0_t const dmaCoreFunction =
         ((quidditch_executable_export_table_v0_t*)exports)
             ->dma_core_ptrs[ordinal];
@@ -240,8 +239,7 @@ iree_status_t quidditch_executable_issue_dispatch_inline(
         for (uint32_t x = 0; x < workgroup_count_x; ++x) {
           workgroup_state.workgroup_id_x = x;
 
-          quidditch_dispatch_queue_workgroup(&workgroup_state);
-          quidditch_dispatch_start_executing_workgroup();
+          quidditch_dispatch_queue_subgroups(&workgroup_state);
 
           dmaCoreFunction(&executable->environment, dispatch_state,
                           &workgroup_state);


### PR DESCRIPTION
A previous PR implemented tiling of parallel dimensions to `scf.forall` but did not yet implement the lowering of `scf.forall`. This PR implements the lowering of `scf.forall` and distributing it to every compute core. This is achieved using the `quidditch_snitch` op which returns an id of 0 to `compute_cores - 1`. We then lower the `scf.forall` to an `scf.for` where each compute core takes an `1/compute_cores` slice of the iteration space.