### PR TITLE
[compiler] Add `remove-trivial-loops` pass for dead `scf.for`s

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
         ::PassesIncGen
         Quidditch::Dialect::Snitch::IR::QuidditchSnitchDialect
         MLIRIR
+        MLIRAffineDialect
         MLIRLinalgDialect
         MLIRBufferizationDialect
         iree::compiler::Dialect::HAL::IR

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
@@ -63,6 +63,7 @@ def SpecializeDMACodePass : Pass<"quidditch-specialize-dma-code",
 
 def LowerForallOpPass : Pass<"quidditch-lower-forall-op"> {
   let dependentDialects = [
+    "mlir::affine::AffineDialect",
     "quidditch::Snitch::QuidditchSnitchDialect",
   ];
 }

--- a/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
         "DisableQuidditchVariant.cpp"
         "LinkExecutables.cpp"
         "ReluToMax.cpp"
+        "RemoveTrivialLoops.cpp"
         "TensorTile.cpp"
         DEPS
         ::PassesIncGen

--- a/codegen/compiler/src/Quidditch/Target/Passes.td
+++ b/codegen/compiler/src/Quidditch/Target/Passes.td
@@ -43,4 +43,10 @@ def TensorTilePass : InterfacePass<"quidditch-tensor-tile",
   ];
 }
 
+def RemoveTrivialLoopsPass
+  : InterfacePass<"quidditch-remove-trivial-loops",
+      "mlir::FunctionOpInterface"> {
+
+}
+
 #endif

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -176,7 +176,7 @@ public:
         .addPass([] { return createTileAndDistributeToWorkgroupsPass(); })
         .addPass([] { return createConvertToDestinationPassingStylePass(); })
         .addPass(createFoldAffineMinInDistributedLoopsPass)
-        .addPass(createRemoveSingleIterationLoopPass)
+        .addPass(quidditch::createRemoveTrivialLoopsPass)
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass)
         .addPass(createFuseTensorPadWithConsumerPass)
@@ -234,7 +234,7 @@ public:
         .addPass(createCSEPass)
         .addPass(createLoopInvariantCodeMotionPass)
         .addPass(createLinalgGeneralizeNamedOpsPass)
-        .addPass(createRemoveSingleIterationLoopPass)
+        .addPass(quidditch::createRemoveTrivialLoopsPass)
         .addPass(quidditch::Snitch::createFormMicrokernelsPass);
 
     modulePassManager.addPass(quidditch::Snitch::createSpecializeDMACodePass());

--- a/codegen/compiler/src/Quidditch/Target/RemoveTrivialLoops.cpp
+++ b/codegen/compiler/src/Quidditch/Target/RemoveTrivialLoops.cpp
@@ -1,0 +1,104 @@
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
+#include "iree/compiler/Codegen/Common/PassDetail.h"
+#include "iree/compiler/Codegen/Common/Passes.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+// Adapted from IREE's upstream RemoveTrivialLoops pass.
+// TODO: Could make an interface (or reuse an interface from upstream?) to make
+// it more generic and useable for us downstream.
+
+namespace quidditch {
+#define GEN_PASS_DEF_REMOVETRIVIALLOOPSPASS
+#include "Quidditch/Target/Passes.h.inc"
+} // namespace quidditch
+
+using namespace mlir;
+using namespace iree_compiler;
+
+/// If the value is a threadID return the range [0, workgroupSize-1].
+/// If the number of workgroup is known also return the range of workgroupId ad
+/// workgroupCount.
+static std::optional<std::pair<AffineExpr, AffineExpr>>
+getWorkgroupRange(Value processorValue,
+                  std::optional<IntegerAttr> numComputeCores,
+                  ArrayRef<int64_t> workgroupCount) {
+  if (auto idOp =
+          processorValue.getDefiningOp<quidditch::Snitch::ClusterIndexOp>()) {
+    if (!numComputeCores)
+      return std::nullopt;
+
+    OpBuilder b(processorValue.getContext());
+    AffineExpr zero = b.getAffineConstantExpr(0);
+    AffineExpr ubExpr =
+        b.getAffineConstantExpr(numComputeCores->getValue().getZExtValue());
+    return std::make_pair(zero, ubExpr - 1);
+  }
+
+  if (workgroupCount.empty() ||
+      llvm::any_of(workgroupCount, ShapedType::isDynamic))
+    return std::nullopt;
+
+  if (auto idOp =
+          processorValue.getDefiningOp<IREE::HAL::InterfaceWorkgroupIDOp>()) {
+    OpBuilder builder(processorValue.getContext());
+
+    // Can't infer the range when workroupCount is unknown.
+    unsigned index = idOp.getDimension().getZExtValue();
+    if (!workgroupCount[index])
+      return std::nullopt;
+
+    AffineExpr zero = builder.getAffineConstantExpr(0);
+    AffineExpr ubExpr = builder.getAffineConstantExpr(workgroupCount[index]);
+    return std::make_pair(zero, ubExpr - 1);
+  }
+  if (auto dimOp = processorValue
+                       .getDefiningOp<IREE::HAL::InterfaceWorkgroupCountOp>()) {
+    OpBuilder builder(processorValue.getContext());
+
+    // Can't infer the range when workroupCount is unknown.
+    unsigned index = dimOp.getDimension().getZExtValue();
+    if (!workgroupCount[index])
+      return std::nullopt;
+
+    AffineExpr bound = builder.getAffineConstantExpr(workgroupCount[index]);
+    return std::make_pair(bound, bound);
+  }
+  return std::nullopt;
+}
+
+static LogicalResult removeOneTripTiledLoops(FunctionOpInterface funcOp,
+                                             ArrayRef<int64_t> numWorkgroups) {
+  std::optional<IntegerAttr> attr = getConfigIntegerAttr(
+      IREE::HAL::ExecutableTargetAttr::lookup(funcOp), "compute_cores");
+
+  auto getWorkgroupRangeFn = [&](Value processorValue, SmallVectorImpl<Value> &,
+                                 SmallVectorImpl<Value> &) {
+    return getWorkgroupRange(processorValue, attr, numWorkgroups);
+  };
+  RewritePatternSet patterns(funcOp.getContext());
+  populateRemoveSingleIterationLoopPattern(patterns, getWorkgroupRangeFn);
+  return applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+}
+
+namespace {
+
+class RemoveTrivialLoops final
+    : public quidditch::impl::RemoveTrivialLoopsPassBase<RemoveTrivialLoops> {
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+
+    SmallVector<int64_t> numWorkgroups = getStaticNumWorkgroups(funcOp);
+    if (failed(removeOneTripTiledLoops(funcOp, numWorkgroups))) {
+      return signalPassFailure();
+    }
+  }
+};
+} // namespace

--- a/codegen/tests/Target/remove-trivial-loops.mlir
+++ b/codegen/tests/Target/remove-trivial-loops.mlir
@@ -1,0 +1,21 @@
+// RUN: quidditch-opt %s -p "builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(quidditch-remove-trivial-loops)))))" --allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: @test
+hal.executable @test {
+  // CHECK-LABEL: hal.executable.variant public @static
+  hal.executable.variant @static target(#hal.executable.target<"", "", {compute_cores = 8 : i32}>) {
+    builtin.module {
+      // CHECK-LABEL: func @test
+      func.func @test() {
+        %0 = quidditch_snitch.cluster_index
+        %1 = arith.constant 8 : index
+        // CHECK-NOT: scf.for
+        scf.for %arg3 = %0 to %1 step %1 {
+          "test.op"(%arg3) : (index) -> ()
+          scf.yield
+        }
+        return
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is mostly a port of the same pass from IREE but specializing for our `cluster_index` operation and its range.