### PR TITLE
[quidditch_snitch] Introduce and use `microkernel_fence` op

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -17,7 +17,14 @@ def QuidditchSnitch_MemRefMicrokernelOp
       NoTerminator]> {
 
   let description = [{
+    Operation denoting a region of operations as a microkernel.
+    The region is `IsolatedFromAbove` making all inputs to the microkernel explicit.
+    A later compilation step turns the "uncompiled" microkernel into a compiled
+    `call_microkernel` operation.
 
+    Operations within the Microkernel may be executed asynchronous.
+    Side-effects of operations are therefore only guaranteed to be visible
+    after a subsequent invocation of `microkernel_fence`.
   }];
 
   let arguments = (ins Variadic<AnyType>:$inputs);
@@ -40,7 +47,14 @@ def QuidditchSnitch_CallMicrokernelOp
   : QuidditchSnitch_Op<"call_microkernel"> {
 
   let description = [{
+    Operation denoting a call to a compiled microkernel.
+    The compiled artifact is available as the `riscv_assembly` attribute.
+    `name` is used as a hint for the symbol name of the microkernel and has no
+    semantics.
 
+    The Microkernel may be executed asynchronous.
+    Side-effects of operations are therefore only guaranteed to be visible
+    after a subsequent invocation of `microkernel_fence`.
   }];
 
   let arguments = (ins StrAttr:$name, Variadic<AnyType>:$inputs, StrAttr:$riscv_assembly);
@@ -55,6 +69,19 @@ def QuidditchSnitch_CallMicrokernelOp
 
   let extraClassDeclaration = [{
     static bool supportsArgumentType(mlir::Type type);
+  }];
+}
+
+def QuidditchSnitch_MicrokernelFenceOp : QuidditchSnitch_Op<"microkernel_fence"> {
+
+  let description = [{
+    Execution of this operation guarantees that the side-effects of all
+    previous microkernel invocations are visible as soon as this operation
+    returns.
+  }];
+
+  let assemblyFormat = [{
+    attr-dict
   }];
 }
 

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/microkernel_fence.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/microkernel_fence.mlir
@@ -1,0 +1,8 @@
+// RUN: quidditch-opt %s --quidditch-convert-snitch-to-llvm | FileCheck %s
+
+// CHECK-LABEL: @test
+func.func @test() {
+  // CHECK: llvm.inline_asm has_side_effects "fmv.x.w $0, fa0\0Amv $0, $0", "=r,~{memory}"
+  quidditch_snitch.microkernel_fence
+  return
+}

--- a/codegen/tests/Dialect/Snitch/Transforms/specialize-dma-code.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/specialize-dma-code.mlir
@@ -1,0 +1,61 @@
+// RUN: quidditch-opt %s -p "builtin.module(quidditch-specialize-dma-code)" | FileCheck %s
+
+// CHECK-LABEL: @test(
+// CHECK-SAME: %[[A:[[:alnum:]]+]]: memref<32xf32>
+// CHECK-SAME: %[[B:[[:alnum:]]+]]: memref<32xf32>
+// CHECK-SAME: attributes
+// CHECK-SAME: quidditch_snitch.dma_specialization = @[[DMA_SPECIALIZATION:([[:alnum:]]|\$|_)+]]
+func.func @test(%a : memref<32xf32>, %b : memref<32xf32>) {
+  %view = quidditch_snitch.l1_memory_view -> memref<512xi8>
+  %c0 = arith.constant 0 : index
+  %c256 = arith.constant 256 : index
+  // CHECK: memref.view
+  // CHECK-NEXT: memref.view
+  %a_l1 = memref.view %view[%c0][] : memref<512xi8> to memref<32xf32>
+  %b_l1 = memref.view %view[%c256][] : memref<512xi8> to memref<32xf32>
+
+  // CHECK-NEXT: quidditch_snitch.microkernel_fence
+  // CHECK-NEXT: quidditch_snitch.barrier
+  // CHECK-NEXT: quidditch_snitch.microkernel_fence
+  // CHECK-NEXT: quidditch_snitch.barrier
+  // CHECK-NEXT: quidditch_snitch.barrier
+  quidditch_snitch.start_dma_transfer from %a : memref<32xf32> to %a_l1 : memref<32xf32>
+  %t = quidditch_snitch.start_dma_transfer from %b : memref<32xf32> to %b_l1 : memref<32xf32>
+  quidditch_snitch.wait_for_dma_transfers %t : !quidditch_snitch.dma_token
+
+  // CHECK-NEXT: microkernel
+  // CHECK: }
+  quidditch_snitch.memref.microkernel(%a_l1, %b_l1) : memref<32xf32>, memref<32xf32> {
+  ^bb0(%arg0 : memref<32xf32>, %arg1 : memref<32xf32>):
+    linalg.abs ins(%arg0 : memref<32xf32>) outs(%arg1 : memref<32xf32>)
+  }
+
+  // CHECK-NEXT: quidditch_snitch.microkernel_fence
+  // CHECK-NEXT: quidditch_snitch.barrier
+  // CHECK-NEXT: quidditch_snitch.barrier
+  // CHECK-NEXT: return
+  %t2 = quidditch_snitch.start_dma_transfer from %b_l1 : memref<32xf32> to %b : memref<32xf32>
+  quidditch_snitch.wait_for_dma_transfers %t2 : !quidditch_snitch.dma_token
+  return
+}
+
+// CHECK: @[[DMA_SPECIALIZATION]](
+// CHECK-SAME: %[[A:[[:alnum:]]+]]: memref<32xf32>
+// CHECK-SAME: %[[B:[[:alnum:]]+]]: memref<32xf32>
+
+// CHECK: memref.view
+// CHECK-NEXT: memref.view
+
+// CHECK-NEXT: quidditch_snitch.barrier
+// CHECK-NEXT: quidditch_snitch.start_dma_transfer
+// CHECK-NEXT: quidditch_snitch.barrier
+// CHECK-NEXT: quidditch_snitch.start_dma_transfer
+// CHECK-NEXT: quidditch_snitch.wait_for_dma_transfers
+// CHECK-NEXT: quidditch_snitch.barrier
+
+// CHECK-NEXT: quidditch_snitch.barrier
+// CHECK-NEXT: quidditch_snitch.start_dma_transfer
+// CHECK-NEXT: quidditch_snitch.wait_for_dma_transfers
+// CHECK-NEXT: quidditch_snitch.barrier
+
+// CHECK-NEXT: return


### PR DESCRIPTION
Since the introduction of reduction tiling, we've introduced errors in the kernel code through the introduction of race conditions. We incorrectly assumed that `barrier` ops serve as synchronization points for the FPU and the integer core, but this is not the case. This resulted in scenarios such as the DMA copying an L1 buffer back to DRAM despite the calculation not having finished or (in the reduction tiling case) the DMA overriding an L1 buffer that is still in use.

The new `microkernel_fence` op ensures the FPU (and therefore the microkernel invocations) are in sync with the integer core. The specialization pass conservatively places the op before `start_dma_transfer` operations, similar to the barrier.

This will hurt performance compared to the numbers we've previously been getting, but being fast and wrong is not really useful.