### PR TITLE
[quidditch_snitch][NFC] Add `LoweringConfigAttr`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
         MLIRIR
         MLIRInferTypeOpInterface
         MLIRSupport
+        iree::compiler::Codegen::Dialect::Codegen::IR::IREECodegenDialect
         PUBLIC
 )
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp
@@ -1,11 +1,13 @@
 #include "QuidditchSnitchAttrs.h"
 
-#include "llvm/ADT/TypeSwitch.h"
-#include "mlir/IR/DialectImplementation.h"
-#include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/OpImplementation.h"
+using namespace mlir;
+using namespace quidditch::Snitch;
+using namespace mlir::iree_compiler;
 
-#include "QuidditchSnitchDialect.h"
+//===----------------------------------------------------------------------===//
+// LoweringConfigAttr::LoweringConfigAttrInterface
+//===----------------------------------------------------------------------===//
 
-#define GET_ATTRDEF_CLASSES
-#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp.inc"
+SmallVector<int64_t> LoweringConfigAttr::getWorkgroupTileSizes() const {
+  return llvm::to_vector(getWorkgroupTiles());
+}

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.h
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.h
@@ -1,6 +1,7 @@
 
 #pragma once
 
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.h"
 #include "mlir/IR/Attributes.h"
 
 #define GET_ATTRDEF_CLASSES

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
@@ -2,6 +2,7 @@
 #define QUIDDITCH_DIALECT_SNITCH_QUIDDITCHSNITCHATTRS
 
 include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td"
+include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenInterfaces.td"
 include "mlir/IR/AttrTypeBase.td"
 
 class QuidditchSnitch_Attr<string name, list<Trait> traits = []> :
@@ -12,6 +13,26 @@ def QuidditchSnitch_L1EncodingAttr : QuidditchSnitch_Attr<"L1Encoding"> {
 
   let description = [{
     Attribute used as memory space on a memref to denote it being in L1 memory.
+  }];
+}
+
+def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
+  [DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
+    "getWorkgroupTileSizes",
+  ]>]> {
+  let mnemonic = "lowering_config";
+
+  let description = [{
+    Attribute attached to compute operations to describe parameters used in the
+    lowering process (e.g. tile sizes).
+  }];
+
+  let parameters = (ins
+    ArrayRefParameter<"int64_t">:$workgroup_tiles
+  );
+
+  let assemblyFormat = [{
+    struct(params)
   }];
 }
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
@@ -1,10 +1,16 @@
 #include "QuidditchSnitchDialect.h"
 
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp.inc"
 #include "QuidditchSnitchAttrs.h"
 #include "QuidditchSnitchOps.h"
 #include "QuidditchSnitchTypes.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/OpImplementation.h"
 
-#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp.inc"
+#define GET_ATTRDEF_CLASSES
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp.inc"
 
 using namespace quidditch::Snitch;
 

--- a/codegen/compiler/src/Quidditch/Target/TensorTile.cpp
+++ b/codegen/compiler/src/Quidditch/Target/TensorTile.cpp
@@ -1,5 +1,6 @@
 #include "Passes.h"
 
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.h"
 #include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -215,8 +216,8 @@ void TensorTile::runOnOperation() {
     break;
   case TilingLevel::Reduction:
     funcOp->walk([&](TilingInterface target) {
-      if (IREE::Codegen::LoweringConfigAttrInterface loweringConfig =
-              getLoweringConfig(target))
+      if (auto loweringConfig =
+              getLoweringConfig<quidditch::Snitch::LoweringConfigAttr>(target))
         targetOps.insert(target);
     });
     break;


### PR DESCRIPTION
This op replaces the use of IREE's default `LoweringConfigAttr` with our own to give us a more structured and nicer to use attribute for defining our lowering parameters.