### PR TITLE
[quidditch_snitch] Simplify `copy_tensor`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -93,21 +93,17 @@ def QuidditchSnitch_CopyTensorOp : QuidditchSnitch_Op<"copy_tensor",
       "bufferize", "bufferizesToAllocation"]>]> {
 
   let description = [{
-    Operation performing a copy of a tensor to another memory spaces.
-    If `$transfers_to_l1` is true, then the op ensures that the resulting
-    tensor is in L1 memory.
-    Otherwise, the output tensor is guaranteed to be in L3 memory.
-    This operation is a noop if `$copy` and `$result` are already in the same
-    memory space and bufferization can elide the copy.
+    Operation performing a copy of a tensor to L1 memory space.
+    This operation is a noop if `$copy` and `$result` are already in L1 and
+    bufferization can elide the copy.
   }];
 
-  // TODO: Not a big fan of the UnitAttr. This should be an enum.
-  let arguments = (ins AnyRankedTensor:$copy, UnitAttr:$transfers_to_l1);
+  let arguments = (ins AnyRankedTensor:$copy);
 
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $copy `to` ( `L1` $transfers_to_l1^) : (`L3`)? `:` type($copy) attr-dict
+    $copy `to` `L1` `:` type($copy) attr-dict
   }];
 
   let hasFolder = 1;

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PromoteToL1.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PromoteToL1.cpp
@@ -49,8 +49,7 @@ void PromoteOperandsToL1::runOnOperation() {
     auto builder = OpBuilder(computeOp);
     for (TypedValue<RankedTensorType> value : nonL1Uses) {
       auto copyOp = builder.create<CopyTensorOp>(computeOp.getLoc(),
-                                                 /*copy=*/value,
-                                                 /*transfers_to_l1=*/true);
+                                                 /*copy=*/value);
       value.replaceAllUsesExcept(copyOp, copyOp);
     }
   });
@@ -65,8 +64,8 @@ void PromoteAllocsToL1::runOnOperation() {
     }
 
     OpBuilder builder(tensorOp);
-    Value replacement = builder.create<CopyTensorOp>(
-        tensorOp.getLoc(), tensorOp, /*transfers_to_l1=*/true);
+    Value replacement =
+        builder.create<CopyTensorOp>(tensorOp.getLoc(), tensorOp);
     tensorOp.replaceAllUsesWith(replacement);
     tensorOp.erase();
   });

--- a/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
@@ -40,12 +40,11 @@ func.func @identical_argument(%arg0 : i32) {
 // CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
 func.func @double_copy(%arg0 : tensor<32xf64>) -> tensor<32xf64> {
   // CHECK-NEXT: %[[R:.*]] = quidditch_snitch.copy_tensor %[[ARG0]] to L1
-  %0 = quidditch_snitch.copy_tensor %arg0 to L3 : tensor<32xf64>
+  %0 = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<32xf64>
   %1 = quidditch_snitch.copy_tensor %0 to L1 : tensor<32xf64>
   // CHECK-NEXT: return %[[R]]
   return %1 : tensor<32xf64>
 }
-
 
 // CHECK-LABEL: @wait_gets_removed
 func.func @wait_gets_removed() {


### PR DESCRIPTION
The copy to L3 memory branch was dead code since we never need to explicitly make sure that a tensor is in L3. Copies from L3 back to L1 are inserted implicitly by the bufferization framework and need (and should) not be modelled using the operation.