### PR TITLE
[quidditch_snitch] Fix missing `offset` application on destination po…

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -125,7 +125,7 @@ struct StartDMATransferOp1DLowering
     Value source = sourceDescriptor.bufferPtr(
         rewriter, op->getLoc(), *getTypeConverter(), op.getSource().getType());
     Value dest = destDescriptor.bufferPtr(
-        rewriter, op->getLoc(), *getTypeConverter(), op.getSource().getType());
+        rewriter, op->getLoc(), *getTypeConverter(), op.getDest().getType());
 
     MemRefType sourceMemRef = op.getSource().getType();
     SmallVector<Value> dynamicSizes;
@@ -238,7 +238,7 @@ struct StartDMATransferOp2DLowering
     Value source = sourceDescriptor.bufferPtr(
         rewriter, op->getLoc(), *getTypeConverter(), op.getSource().getType());
     Value dest = destDescriptor.bufferPtr(
-        rewriter, op->getLoc(), *getTypeConverter(), op.getSource().getType());
+        rewriter, op->getLoc(), *getTypeConverter(), op.getDest().getType());
 
     Value elementSize = rewriter.create<LLVM::ConstantOp>(
         op->getLoc(),

--- a/runtime/cmake/quidditch_module.cmake
+++ b/runtime/cmake/quidditch_module.cmake
@@ -120,6 +120,7 @@ function(quidditch_module)
   list(APPEND _COMPILER_ARGS "--iree-llvmcpu-static-library-output-path=${_O_LLVM_FILE_NAME}")
 
   list(APPEND _COMPILER_ARGS "--output-format=vm-c")
+  list(APPEND _COMPILER_ARGS "--iree-flow-trace-dispatch-tensors")
   list(APPEND _COMPILER_ARGS "--iree-vm-target-index-bits=32")
   list(APPEND _COMPILER_ARGS "${_MLIR_SRC}")
   list(APPEND _COMPILER_ARGS "-o")


### PR DESCRIPTION
…inter

Due to a typo the `offset` that needs to be applied to the aligned pointer of a memref was accidently taken from the source memref rather than the memref type of the destination buffer.