### PR TITLE
[ConvertSnitchToLLVM] Make sure DMA strides are in bytes

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -301,8 +301,13 @@ struct StartDMATransferOp2DLowering
 
           Value sourceStride =
               sourceDescriptor.stride(builder, loc, sourceStrides.size() - 1);
+          sourceStride = rewriter.create<LLVM::MulOp>(
+              op->getLoc(), sourceStride, elementSize);
           Value destStride =
               destDescriptor.stride(builder, loc, destStrides.size() - 1);
+          destStride = rewriter.create<LLVM::MulOp>(op->getLoc(), destStride,
+                                                    elementSize);
+
           Value outerLoopSize =
               sourceDescriptor.size(builder, loc, shape.size() - 1);
           return {builder

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer.mlir
@@ -63,8 +63,10 @@ func.func @test5(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[8, 1]
   // CHECK: %[[ARG1_OFFSET:.*]] = llvm.mlir.zero
   // CHECK: %[[ARG1_ADJUSTED:.*]] = llvm.getelementptr %[[ARG1_PTR]][%[[ARG1_OFFSET]]]
 
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.extractvalue %[[ARG0]][4, 0]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.extractvalue %[[ARG1]][4, 0]
+  // CHECK: %[[ARG0_STRIDE_N:.*]] = llvm.extractvalue %[[ARG0]][4, 0]
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG1_STRIDE_N:.*]] = llvm.extractvalue %[[ARG1]][4, 0]
+  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
   // CHECK: %[[DIM0:.*]] = llvm.extractvalue %[[ARG0]][3, 0]
   // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_ADJUSTED]], %[[ARG0_ADJUSTED]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[DIM0]])
   %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>
@@ -105,8 +107,10 @@ func.func @test6(%arg0 : memref<3x2x4xf32>, %arg1 : memref<3x2x4xf32, strided<[1
   // CHECK: %[[ARG1_OFFSET1:.*]] = llvm.add %[[ARG1_OFFSET]], %[[MUL]]
   // CHECK: %[[ARG1_ADJUSTED:.*]] = llvm.getelementptr %[[ARG1_PTR]][%[[ARG1_OFFSET1]]]
 
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.extractvalue %[[ARG0]][4, 1]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.extractvalue %[[ARG1]][4, 1]
+  // CHECK: %[[ARG0_STRIDE_N:.*]] = llvm.extractvalue %[[ARG0]][4, 1]
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG1_STRIDE_N:.*]] = llvm.extractvalue %[[ARG1]][4, 1]
+  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
   // CHECK: %[[DIM1:.*]] = llvm.extractvalue %[[ARG0]][3, 1]
   // CHECK: %[[RES:.*]] = llvm.call @snrt_dma_start_2d(%[[ARG1_ADJUSTED]], %[[ARG0_ADJUSTED]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[DIM1]])
   // CHECK: scf.yield %[[RES]]
@@ -136,8 +140,10 @@ func.func @dynamic_strides(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, stri
   // CHECK: %[[ARG1_OFFSET:.*]] = llvm.mlir.zero
   // CHECK: %[[ARG1_ADJUSTED:.*]] = llvm.getelementptr %[[ARG1_PTR]][%[[ARG1_OFFSET]]]
 
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.extractvalue %[[ARG0]][4, 0]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.extractvalue %[[ARG1]][4, 0]
+  // CHECK: %[[ARG0_STRIDE_N:.*]] = llvm.extractvalue %[[ARG0]][4, 0]
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG1_STRIDE_N:.*]] = llvm.extractvalue %[[ARG1]][4, 0]
+  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
   // CHECK: %[[DIM0:.*]] = llvm.extractvalue %[[ARG0]][3, 0]
   // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_ADJUSTED]], %[[ARG0_ADJUSTED]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[DIM0]])
   %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[?, 1], offset: 0>>


### PR DESCRIPTION
They were accidentally in element type unit, which the DMA does not like nor understand.

We are now back to bit equality with LLVM