### PR TITLE
[TensorTile] Add dedicated L1 tiling

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp
@@ -2,7 +2,6 @@
 
 using namespace mlir;
 using namespace quidditch::Snitch;
-using namespace mlir::iree_compiler;
 
 //===----------------------------------------------------------------------===//
 // LoweringConfigAttr::LoweringConfigAttrInterface

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
@@ -16,6 +16,29 @@ def QuidditchSnitch_L1EncodingAttr : QuidditchSnitch_Attr<"L1Encoding"> {
   }];
 }
 
+def TileSizeList : OptionalArrayRefParameter<"int64_t"> {
+  let parser = [{
+    [&]() -> mlir::FailureOr<llvm::SmallVector<int64_t>> {
+      if ($_parser.parseLSquare())
+        return mlir::failure();
+
+      if (succeeded($_parser.parseOptionalRSquare()))
+        return llvm::SmallVector<int64_t>();
+
+      auto result
+        = mlir::FieldParser<llvm::SmallVector<int64_t>>::parse($_parser);
+      if (mlir::failed(result) || $_parser.parseRSquare())
+        return mlir::failure();
+
+      return result;
+    }()
+  }];
+
+  let printer = [{
+    $_printer << "[" << $_self << "]"
+  }];
+}
+
 def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
   [DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
     "getWorkgroupTileSizes",
@@ -28,11 +51,21 @@ def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
   }];
 
   let parameters = (ins
-    ArrayRefParameter<"int64_t">:$workgroup_tiles
+    TileSizeList:$workgroup_tiles,
+    TileSizeList:$l1_tiles
   );
 
+  let builders = [
+    AttrBuilder<(ins
+      CArg<"llvm::ArrayRef<int64_t>", "{}">:$workgroupTiles,
+      CArg<"llvm::ArrayRef<int64_t>", "{}">:$l1Tiles
+    )>
+  ];
+
+  let skipDefaultBuilders = 1;
+
   let assemblyFormat = [{
-    struct(params)
+    `<` struct(params) `>`
   }];
 }
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
@@ -12,7 +12,33 @@
 #define GET_ATTRDEF_CLASSES
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.cpp.inc"
 
+using namespace mlir;
 using namespace quidditch::Snitch;
+
+static ArrayRef<int64_t> dropTrailingZeros(ArrayRef<int64_t> array) {
+  while (!array.empty()) {
+    if (array.back() != 0)
+      return array;
+
+    array = array.drop_back();
+  }
+  return array;
+}
+
+//===----------------------------------------------------------------------===//
+// LoweringConfigAttr::Builders
+//===----------------------------------------------------------------------===//
+
+LoweringConfigAttr LoweringConfigAttr::get(MLIRContext *context,
+                                           ArrayRef<int64_t> workgroupTiles,
+                                           ArrayRef<int64_t> l1Tiles) {
+  return Base::get(context, dropTrailingZeros(workgroupTiles),
+                   dropTrailingZeros(l1Tiles));
+}
+
+//===----------------------------------------------------------------------===//
+// QuidditchSnitchDialect
+//===----------------------------------------------------------------------===//
 
 void QuidditchSnitchDialect::initialize() {
   addOperations<

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -86,7 +86,7 @@ def QuidditchSnitch_MicrokernelFenceOp : QuidditchSnitch_Op<"microkernel_fence">
 }
 
 def QuidditchSnitch_CopyTensorOp : QuidditchSnitch_Op<"copy_tensor",
-  [SameOperandsAndResultType, NoMemoryEffect,
+  [SameOperandsAndResultType, Pure,
    DeclareOpInterfaceMethods<BufferizableOpInterface,
     ["resultBufferizesToMemoryWrite", "bufferizesToMemoryRead",
      "bufferizesToMemoryWrite", "getAliasingValues", "getBufferType",

--- a/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
+++ b/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
@@ -55,34 +55,41 @@ static LogicalResult setRootConfig(FunctionOpInterface funcOp,
         //   once + needing to copy back the result fewer times). This could
         //   come at the cost of concurrency for distributing workgroups but is
         //   only applicable once on Occamy.
-        SmallVector<int64_t> bounds(3, 0);
+        SmallVector<int64_t> workgroupTiles(3, 0);
+        SmallVector<int64_t> l1Tiles(3, 0);
 
         if (funcOp.getName() ==
             "main$async_dispatch_0_matmul_transpose_b_1x400x161_f64") {
-          bounds[1] = 40;
-          bounds[2] = 0;
+          l1Tiles[1] = 40;
+          l1Tiles[2] = 0;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_7_matmul_transpose_b_1x600x400_f64") {
-          bounds[0] = 0;
-          bounds[1] = 24;
-          bounds[2] = 0;
+          workgroupTiles[2] = 200;
+
+          l1Tiles[0] = 0;
+          l1Tiles[1] = 40;
+          l1Tiles[2] = 0;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_8_matmul_transpose_b_1x600x600_f64") {
-          bounds[0] = 0;
-          bounds[1] = 40;
-          bounds[2] = 300;
+          workgroupTiles[2] = 200;
+
+          l1Tiles[0] = 0;
+          l1Tiles[1] = 40;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_1_matmul_transpose_b_1x1200x400_f64") {
-          bounds[0] = 0;
-          bounds[1] = 24;
-          bounds[2] = 0;
+          workgroupTiles[2] = 200;
+
+          l1Tiles[0] = 0;
+          l1Tiles[1] = 40;
+          l1Tiles[2] = 0;
         }
 
-        setLoweringConfig(rootOp, quidditch::Snitch::LoweringConfigAttr::get(
-                                      rootOp->getContext(), bounds));
+        setLoweringConfig(rootOp,
+                          quidditch::Snitch::LoweringConfigAttr::get(
+                              rootOp->getContext(), workgroupTiles, l1Tiles));
         return success();
       })
       .Default(success());

--- a/codegen/compiler/src/Quidditch/Target/Passes.h
+++ b/codegen/compiler/src/Quidditch/Target/Passes.h
@@ -7,7 +7,14 @@
 namespace quidditch {
 
 enum class TilingLevel {
+  /// Applies any reduction tiling that was specified in the workgroup tile
+  /// sizes list but could not be be performed by workgroup tiling.
   Reduction,
+  /// Performs tiling within a workgroup to fit all tensors required for the
+  /// root operation into L1.
+  L1,
+  /// Performs tiling and distribution of compute operations to all compute
+  /// cores within a workgroup.
   Thread
 };
 

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -187,6 +187,9 @@ public:
         })
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass)
+        .addPass([] {
+          return quidditch::createTensorTilePass({quidditch::TilingLevel::L1});
+        })
         .addPass(quidditch::Snitch::createPromoteOperandsToL1Pass)
         // TODO: Fuse scf.forall after.
         .addPass([] {

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -195,7 +195,10 @@ public:
         .addPass([] {
           return quidditch::createTensorTilePass(
               {quidditch::TilingLevel::Thread});
-        });
+        })
+        .addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
+        .addPass(createLoopInvariantCodeMotionPass);
 
     BufferizationOptions::AllocationFn allocationFn =
         [](OpBuilder &builder, Location loc, MemRefType memRefType,


### PR DESCRIPTION
Previously, workgroup tiling was responsible for two things:
* Making sure the working set fits into L1 memory and
* Splitting into workgroups for distribution

However, this is undesirable as this forces us to choose a tile size satisfying both requirements. Instead, this PR adds a new level of tiling called L1 tiling which takes over the responsibility of making the working set fit into L1 memory. Workgroup distribution tiling is now solely responsible for workgroup concurrency. As we are currently compiling for just one snitch cluster, the existing tile sizes have been changed to L1 tile sizes except the reduction dimension. The reduction dimension tiling should come prior to L1 tiling, which happens to be the case right now. Larger workgroups are desirable in the absence of concurrency as we avoid redundant data transfer of workgroup-id invariant data (input and ouput vectors in the mat-vec) + any launch overhead.

Future multibuffering also depends on one workgroup operating on tensors larger than L1 memory prior to L1 tiling