### PR TITLE
[quidditch_snitch] Introduce asynchronous tensor copy ops

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -85,28 +85,72 @@ def QuidditchSnitch_MicrokernelFenceOp : QuidditchSnitch_Op<"microkernel_fence">
   }];
 }
 
-def QuidditchSnitch_CopyTensorOp : QuidditchSnitch_Op<"copy_tensor",
-  [SameOperandsAndResultType, Pure,
+def QuidditchSnitch_StartTensorCopyOp : QuidditchSnitch_Op<"start_tensor_copy",
+  [AllTypesMatch<["copy", "result"]>, Pure,
    DeclareOpInterfaceMethods<BufferizableOpInterface,
     ["resultBufferizesToMemoryWrite", "bufferizesToMemoryRead",
      "bufferizesToMemoryWrite", "getAliasingValues", "getBufferType",
       "bufferize", "bufferizesToAllocation"]>]> {
 
   let description = [{
-    Operation performing a copy of a tensor to L1 memory space.
+    Operation starting a copy of a tensor to L1 memory space returning it as
+    a new tensor.
+    The contained values of the tensor in an unspecified state.
+    See `wait_for_tensor_copy` to transform the tensor value into a state
+    equal to `$copy`.
+
     This operation is a noop if `$copy` and `$result` are already in L1 and
     bufferization can elide the copy.
   }];
 
   let arguments = (ins AnyRankedTensor:$copy);
 
-  let results = (outs AnyRankedTensor:$result);
+  let results = (outs
+    AnyRankedTensor:$result,
+    QuidditchSnitch_DMATokenType:$token
+  );
 
   let assemblyFormat = [{
     $copy `to` `L1` `:` type($copy) attr-dict
   }];
+}
 
-  let hasFolder = 1;
+def QuidditchSnitch_WaitForTensorCopyOp : QuidditchSnitch_Op<"wait_for_tensor_copy",
+  [AllTypesMatch<["transfer_tensor", "result", "copy"]>, Pure,
+   DeclareOpInterfaceMethods<BufferizableOpInterface,
+    ["bufferizesToMemoryRead", "bufferizesToMemoryWrite", "getAliasingValues",
+     "bufferize", "mustBufferizeInPlace", "isNotConflicting"]>]> {
+
+  let description = [{
+    Operation asserting that a previous `start_tensor_copy` operation has finished.
+    Unless `token` is the result of an `completed_token` operation,
+    `transfer_tensor` and `token` must at runtime be a token and tensor yielded
+    by a `start_tensor_copy` operation and `copy` the original tensor used in
+    `start_tensor_copy`.
+
+    Once this operation returns, the returned tensor's values are guaranteed
+    equal to the `copy` operand and in L1 memory.
+
+    Note: The additional `copy` operand is given as it is effectively read by
+    this operation.
+    This additionally guarantees that the bufferization frame work does not
+    perform a write to the underlying buffer of `copy` while the transfer is
+    in progress.
+  }];
+
+  let arguments = (ins
+    AnyRankedTensor:$transfer_tensor,
+    QuidditchSnitch_DMATokenType:$token,
+    AnyRankedTensor:$copy
+  );
+
+  let results = (outs
+    AnyRankedTensor:$result
+  );
+
+  let assemblyFormat = [{
+    `of` $copy `to` $transfer_tensor `using` $token `:` type($transfer_tensor) attr-dict
+  }];
 }
 
 def FlatI8MemRef : ConfinedType<MemRefOf<[I8]>, [HasStaticShapePred,

--- a/codegen/tests/Dialect/Snitch/IR/bufferization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/bufferization.mlir
@@ -1,26 +1,29 @@
 // RUN: quidditch-opt %s --one-shot-bufferize | FileCheck %s
 
 // CHECK: func @copy_l1_buffer(
-func.func @copy_l1_buffer(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
+func.func @copy_l1_buffer(%arg0 : tensor<32xf32>) -> (tensor<32xf32>, !quidditch_snitch.dma_token) {
   // CHECK: %[[ARG0:.*]] = bufferization.to_memref
 
   // CHECK: %[[ALLOC:.*]] = memref.alloc()
   // CHECK-SAME: : memref<32xf32, #quidditch_snitch.l1_encoding>
-  // CHECK: memref.copy %[[ARG0]], %[[ALLOC]]
+  // CHECK: %[[TOKEN:.*]] = quidditch_snitch.start_dma_transfer from %[[ARG0]]
+  // CHECK-SAME: to %[[ALLOC]]
   // CHECK: %[[R:.*]] = bufferization.to_tensor %[[ALLOC]]
-  %r = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<32xf32>
-  // CHECK: return %[[R]]
-  return %r : tensor<32xf32>
+  %r, %token = quidditch_snitch.start_tensor_copy %arg0 to L1 : tensor<32xf32>
+  // CHECK: return %[[R]], %[[TOKEN]]
+  return %r, %token : tensor<32xf32>, !quidditch_snitch.dma_token
 }
 
 // CHECK: func @copy_l1_buffer_elided(
 func.func @copy_l1_buffer_elided(%arg0 : tensor<32xf32>) -> tensor<32xf32> {
   // CHECK: memref.alloc()
   // CHECK-NOT: memref.alloc()
-  %r = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<32xf32>
-  %r2 = quidditch_snitch.copy_tensor %r to L1 : tensor<32xf32>
+  %r:2 = quidditch_snitch.start_tensor_copy %arg0 to L1 : tensor<32xf32>
+  %r2 = quidditch_snitch.wait_for_tensor_copy of %arg0 to %r#0 using %r#1 : tensor<32xf32>
+  %r3:2 = quidditch_snitch.start_tensor_copy %r2 to L1 : tensor<32xf32>
+  %r4 = quidditch_snitch.wait_for_tensor_copy of %r2 to %r3#0 using %r3#1 : tensor<32xf32>
   // CHECK: return
-  return %r2 : tensor<32xf32>
+  return %r4 : tensor<32xf32>
 }
 
 // CHECK: func @copy_l1_buffer_alloca_elided(
@@ -28,9 +31,9 @@ func.func @copy_l1_buffer_alloca_elided() -> tensor<32xf32> {
   // CHECK: memref.alloc()
   // CHECK-NOT: memref.alloc()
   %r = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding} : tensor<32xf32>
-  %r2 = quidditch_snitch.copy_tensor %r to L1 : tensor<32xf32>
+  %r2:2 = quidditch_snitch.start_tensor_copy %r to L1 : tensor<32xf32>
   // CHECK: return
-  return %r2 : tensor<32xf32>
+  return %r2#0 : tensor<32xf32>
 }
 
 // CHECK: func @scf_for_copy_l1_buffer(
@@ -39,14 +42,16 @@ func.func @scf_for_copy_l1_buffer() -> tensor<32xf32> {
   %c1 = arith.constant 1 : index
   // CHECK: %[[MEMREF:.*]] = memref.alloc
   %r = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding} : tensor<32xf32>
-  %r2 = quidditch_snitch.copy_tensor %r to L1 : tensor<32xf32>
+  %r2:2 = quidditch_snitch.start_tensor_copy %r to L1 : tensor<32xf32>
+  // CHECK-NEXT: quidditch_snitch.completed_token
   // CHECK-NEXT: %[[R:.*]] = scf.for
   // CHECK-SAME: iter_args(%[[ITER:.*]] = %[[MEMREF]])
+  // CHECK-NEXT: quidditch_snitch.completed_token
   // CHECK-NEXT: scf.yield %[[ITER]]
   // CHECK: bufferization.to_tensor %[[R]]
-  %r3 = scf.for %i = %c0 to %c1 step %c1 iter_args(%iter = %r2) -> (tensor<32xf32>) {
-    %r4 = quidditch_snitch.copy_tensor %iter to L1 : tensor<32xf32>
-    scf.yield %r4 : tensor<32xf32>
+  %r3 = scf.for %i = %c0 to %c1 step %c1 iter_args(%iter = %r2#0) -> (tensor<32xf32>) {
+    %r4:2 = quidditch_snitch.start_tensor_copy %iter to L1 : tensor<32xf32>
+    scf.yield %r4#0 : tensor<32xf32>
   }
   return %r3 : tensor<32xf32>
 }
@@ -58,9 +63,10 @@ func.func @copy_l1_buffer_dynamic_dims(%arg0 : tensor<?xf32>) -> tensor<?xf32> {
   // CHECK: %[[DIM:.*]] = memref.dim %[[ARG0]], %[[ZERO]]
   // CHECK: %[[ALLOC:.*]] = memref.alloc(%[[DIM]])
   // CHECK-SAME: : memref<?xf32, #quidditch_snitch.l1_encoding>
-  // CHECK: memref.copy %[[ARG0]], %[[ALLOC]]
+  // CHECK: quidditch_snitch.start_dma_transfer from %[[ARG0]]
+  // CHECK-SAME: to %[[ALLOC]]
   // CHECK: %[[R:.*]] = bufferization.to_tensor %[[ALLOC]]
-  %r = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<?xf32>
+  %r:2 = quidditch_snitch.start_tensor_copy %arg0 to L1 : tensor<?xf32>
   // CHECK: return %[[R]]
-  return %r : tensor<?xf32>
+  return %r#0 : tensor<?xf32>
 }

--- a/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/canonicalization.mlir
@@ -36,16 +36,6 @@ func.func @identical_argument(%arg0 : i32) {
   return
 }
 
-// CHECK-LABEL: @double_copy
-// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
-func.func @double_copy(%arg0 : tensor<32xf64>) -> tensor<32xf64> {
-  // CHECK-NEXT: %[[R:.*]] = quidditch_snitch.copy_tensor %[[ARG0]] to L1
-  %0 = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<32xf64>
-  %1 = quidditch_snitch.copy_tensor %0 to L1 : tensor<32xf64>
-  // CHECK-NEXT: return %[[R]]
-  return %1 : tensor<32xf64>
-}
-
 // CHECK-LABEL: @wait_gets_removed
 func.func @wait_gets_removed() {
   // CHECK-NEXT: return

--- a/codegen/tests/Dialect/Snitch/IR/roundtrip.mlir
+++ b/codegen/tests/Dialect/Snitch/IR/roundtrip.mlir
@@ -8,7 +8,7 @@ func.func @test(%arg0 : memref<f64>) {
   return
 }
 
-func.func @test3(%arg0 : tensor<?x4xf64>) -> tensor<?x4xf64> {
-  %0 = quidditch_snitch.copy_tensor %arg0 to L1 : tensor<?x4xf64>
-  return %0 : tensor<?x4xf64>
+func.func @test3(%arg0 : tensor<?x4xf64>) -> (tensor<?x4xf64>, !quidditch_snitch.dma_token) {
+  %0:2 = quidditch_snitch.start_tensor_copy %arg0 to L1 : tensor<?x4xf64>
+  return %0#0, %0#1 : tensor<?x4xf64>, !quidditch_snitch.dma_token
 }

--- a/codegen/tests/Dialect/Snitch/Transforms/promote-operands-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-operands-to-l1.mlir
@@ -6,9 +6,12 @@
 func.func @test(%a : tensor<32x32xf32>, %b : tensor<32x32xf32>) -> tensor<32x32xf32> {
   // CHECK: %[[E:.*]] = bufferization.alloc_tensor
   %e = bufferization.alloc_tensor() : tensor<32x32xf32>
-  // CHECK: %[[A2:.*]] = quidditch_snitch.copy_tensor %[[A]] to L1
-  // CHECK: %[[B2:.*]] = quidditch_snitch.copy_tensor %[[B]] to L1
-  // CHECK: %[[E2:.*]] = quidditch_snitch.copy_tensor %[[E]] to L1
+  // CHECK: %[[A1:.*]], %[[TOKEN:.*]] = quidditch_snitch.start_tensor_copy %[[A]] to L1
+  // CHECK: %[[A2:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[A]] to %[[A1]] using %[[TOKEN]]
+  // CHECK: %[[B1:.*]], %[[TOKEN:.*]] = quidditch_snitch.start_tensor_copy %[[B]] to L1
+  // CHECK: %[[B2:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[B]] to %[[B1]] using %[[TOKEN]]
+  // CHECK: %[[E1:.*]], %[[TOKEN:.*]] = quidditch_snitch.start_tensor_copy %[[E]] to L1
+  // CHECK: %[[E2:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[E]] to %[[E1]] using %[[TOKEN]]
   // CHECK: linalg.matmul ins(%[[A2]], %[[B2]] : {{.*}}) outs(%[[E2]] : {{.*}})
   %r = linalg.matmul ins(%a, %b : tensor<32x32xf32>, tensor<32x32xf32>) outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
   return %r : tensor<32x32xf32>

--- a/test.mlir
+++ b/test.mlir
@@ -1,0 +1,79 @@
+func.func @main$async_dispatch_0_matmul_transpose_b_1x400x161_f64() attributes {translation_info = #iree_codegen.translation_info<None>} {
+  %c40 = arith.constant 40 : index
+  %c400 = arith.constant 400 : index
+  %cst = arith.constant 0.000000e+00 : f64
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c515200 = arith.constant 515200 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x161xf64>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<400x161xf64>>
+  %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c515200) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<1x400xf64>>
+  %3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<1x400xf64>>
+  %4 = flow.dispatch.tensor.load %3, offsets = [0, 0], sizes = [1, 400], strides = [1, 1] : !flow.dispatch.tensor<writeonly:tensor<1x400xf64>> -> tensor<1x400xf64>
+  %5 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [1, 161], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x161xf64>> -> tensor<1x161xf64>
+  %6 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [400, 161], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<400x161xf64>> -> tensor<400x161xf64>
+  %7 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [1, 400], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<1x400xf64>> -> tensor<1x400xf64>
+  %8 = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding} : tensor<1x400xf64>
+  %result, %token = quidditch_snitch.start_tensor_copy %8 to L1 : tensor<1x400xf64>
+  %9 = quidditch_snitch.wait_for_tensor_copy %token, %result : tensor<1x400xf64>
+  %10 = scf.forall (%arg0) = (0) to (400) step (50) shared_outs(%arg1 = %9) -> (tensor<1x400xf64>) {
+    %extracted_slice = tensor.extract_slice %arg1[0, %arg0] [1, 50] [1, 1] : tensor<1x400xf64> to tensor<1x50xf64>
+    %17 = linalg.fill ins(%cst : f64) outs(%extracted_slice : tensor<1x50xf64>) -> tensor<1x50xf64>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %17 into %arg1[0, %arg0] [1, 50] [1, 1] : tensor<1x50xf64> into tensor<1x400xf64>
+    }
+  }
+
+  %result_0, %token_1 = quidditch_snitch.start_tensor_copy %5 to L1 : tensor<1x161xf64>
+  %11 = quidditch_snitch.wait_for_tensor_copy %token_1, %result_0 : tensor<1x161xf64>
+
+  %first_slice = tensor.extract_slice %6[0, 0] [40, 161] [1, 1] : tensor<400x161xf64> to tensor<40x161xf64>
+  %first_result, %first_token = quidditch_snitch.start_tensor_copy %first_slice to L1 : tensor<40x161xf64>
+  %storage = bufferization.alloc_tensor() {memory_space = #quidditch_snitch.l1_encoding} : tensor<40x161xf64>
+
+  %12:4 = scf.for %arg0 = %c0 to %c400 step %c40 iter_args(%arg1 = %10, %iter_token = %first_token, %iter_tensor = %first_result, %next_storage = %storage) -> (tensor<1x400xf64>, !quidditch_snitch.dma_token, tensor<40x161xf64>, tensor<40x161xf64>) {
+    %next = arith.addi %arg0, %c40 : index
+    %next_slice = tensor.extract_slice %6[%next, 0] [40, 161] [1, 1] : tensor<400x161xf64> to tensor<40x161xf64>
+    %next_result = linalg.copy ins(%next_slice : tensor<40x161xf64>) outs(%next_storage : tensor<40x161xf64>) -> tensor<40x161xf64>
+    %next_token = quidditch_snitch.completed_token
+
+    %extracted_slice_8 = tensor.extract_slice %arg1[0, %arg0] [1, 40] [1, 1] : tensor<1x400xf64> to tensor<1x40xf64>
+    %result_11, %token_12 = quidditch_snitch.start_tensor_copy %extracted_slice_8 to L1 : tensor<1x40xf64>
+    %17 = quidditch_snitch.wait_for_tensor_copy %iter_token, %iter_tensor : tensor<40x161xf64>
+    %18 = quidditch_snitch.wait_for_tensor_copy %token_12, %result_11 : tensor<1x40xf64>
+    %19 = scf.forall (%arg2) = (0) to (40) step (5) shared_outs(%arg3 = %18) -> (tensor<1x40xf64>) {
+      %extracted_slice_13 = tensor.extract_slice %17[%arg2, 0] [5, 161] [1, 1] : tensor<40x161xf64> to tensor<5x161xf64>
+      %extracted_slice_14 = tensor.extract_slice %arg3[0, %arg2] [1, 5] [1, 1] : tensor<1x40xf64> to tensor<1x5xf64>
+      %20 = linalg.matmul_transpose_b {lowering_config = #quidditch_snitch.lowering_config<l1_tiles = [0, 40]>} ins(%11, %extracted_slice_13 : tensor<1x161xf64>, tensor<5x161xf64>) outs(%extracted_slice_14 : tensor<1x5xf64>) -> tensor<1x5xf64>
+      scf.forall.in_parallel {
+        tensor.parallel_insert_slice %20 into %arg3[0, %arg2] [1, 5] [1, 1] : tensor<1x5xf64> into tensor<1x40xf64>
+      }
+    }
+    %inserted_slice = tensor.insert_slice %19 into %arg1[0, %arg0] [1, 40] [1, 1] : tensor<1x40xf64> into tensor<1x400xf64>
+    scf.yield %inserted_slice, %next_token, %next_result, %17 : tensor<1x400xf64>, !quidditch_snitch.dma_token, tensor<40x161xf64>, tensor<40x161xf64>
+  }
+
+
+
+  %result_2, %token_3 = quidditch_snitch.start_tensor_copy %12#0 to L1 : tensor<1x400xf64>
+  %13 = quidditch_snitch.wait_for_tensor_copy %token_3, %result_2 : tensor<1x400xf64>
+  %result_4, %token_5 = quidditch_snitch.start_tensor_copy %7 to L1 : tensor<1x400xf64>
+  %14 = quidditch_snitch.wait_for_tensor_copy %token_5, %result_4 : tensor<1x400xf64>
+  %result_6, %token_7 = quidditch_snitch.start_tensor_copy %4 to L1 : tensor<1x400xf64>
+  %15 = quidditch_snitch.wait_for_tensor_copy %token_7, %result_6 : tensor<1x400xf64>
+  %16 = scf.forall (%arg0) = (0) to (400) step (50) shared_outs(%arg1 = %15) -> (tensor<1x400xf64>) {
+    %extracted_slice = tensor.extract_slice %13[0, %arg0] [1, 50] [1, 1] : tensor<1x400xf64> to tensor<1x50xf64>
+    %extracted_slice_8 = tensor.extract_slice %14[0, %arg0] [1, 50] [1, 1] : tensor<1x400xf64> to tensor<1x50xf64>
+    %extracted_slice_9 = tensor.extract_slice %arg1[0, %arg0] [1, 50] [1, 1] : tensor<1x400xf64> to tensor<1x50xf64>
+    %17 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%extracted_slice, %extracted_slice_8 : tensor<1x50xf64>, tensor<1x50xf64>) outs(%extracted_slice_9 : tensor<1x50xf64>) {
+    ^bb0(%in: f64, %in_10: f64, %out: f64):
+      %18 = arith.addf %in, %in_10 : f64
+      linalg.yield %18 : f64
+    } -> tensor<1x50xf64>
+    scf.forall.in_parallel {
+      tensor.parallel_insert_slice %17 into %arg1[0, %arg0] [1, 50] [1, 1] : tensor<1x50xf64> into tensor<1x400xf64>
+    }
+  }
+  flow.dispatch.tensor.store %16, %3, offsets = [0, 0], sizes = [1, 400], strides = [1, 1] : tensor<1x400xf64> -> !flow.dispatch.tensor<writeonly:tensor<1x400xf64>>
+  return
+}


### PR DESCRIPTION
The current tensor copy is fully synchronous that prevents us from doing transfer optimization utilizing the asynchronous nature of the DMA. While these could be done on MemRefs, having them operate on tensors preserves the use-def chain and allows us not to care about aliasing.