### PR TITLE
[ConvertSnitchToLLVM] Implement single token wait

### DIFF
--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_wait.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_wait.mlir
@@ -2,8 +2,13 @@
 
 // CHECK-LABEL: @test
 func.func @test(%arg0 : !quidditch_snitch.dma_token) {
-  // TODO: This should be a call to snrt_dma_wait but is currently bugged.
-  // CHECK: call @snrt_dma_wait_all()
+  // CHECK: %[[ARG0:.*]] = builtin.unrealized_conversion_cast
+  // CHECK: scf.while
+  // CHECK-NEXT: %[[ID:.*]] = llvm.inline_asm has_side_effects ".insn r 0x2b, 0, 0b100, $0, zero, zero
+  // CHECK-SAME: "=r"
+  // CHECK-SAME: -> i32
+  // CHECK: %[[COND:.*]] = llvm.icmp "ult" %[[ID]], %[[ARG0]]
+  // CHECK: scf.condition(%[[COND]])
   quidditch_snitch.wait_for_dma_transfers %arg0 : !quidditch_snitch.dma_token
   return
 }


### PR DESCRIPTION
Up until now all `wait_for_dma_transfers` ops did not only wait for the transfers denoted by the tokens to be completed, but all transfers within the DMA. This blocks implementing transformations such as pipelining and is generally very unoptimized.