### PR TITLE
[quidditch_snitch] Implement lowering of `pipeline` op

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
         "FormMicrokernels.cpp"
         "LowerForallOp.cpp"
         "LowerL1Allocations.cpp"
+        "LowerPipelineOp.cpp"
         "PromoteToL1.cpp"
         "SpecializeDMACode.cpp"
         DEPS

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerPipelineOp.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerPipelineOp.cpp
@@ -1,0 +1,250 @@
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
+
+namespace quidditch::Snitch {
+#define GEN_PASS_DEF_LOWERPIPELINEOPPASS
+#include "Quidditch/Dialect/Snitch/Transforms/Passes.h.inc"
+} // namespace quidditch::Snitch
+
+namespace {
+class LowerPipelineOp
+    : public quidditch::Snitch::impl::LowerPipelineOpPassBase<LowerPipelineOp> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+using namespace mlir;
+using namespace quidditch::Snitch;
+
+/// Duplicate resources required by a stage to support concurrent execution of
+/// the stage and switches on it. Currently only supports `memref.alloca`.
+static void makeResourceUsageExplicit(PipelineOp pipelineOp) {
+  pipelineOp->walk([&](memref::AllocaOp allocation) {
+    // TODO: Pipeline independent dynamic allocations would be fine.
+    assert(allocation.getDynamicSizes().empty() &&
+           "dynamic allocations not supported");
+    Location loc = allocation->getLoc();
+
+    // Clone right before the pipeline op as many times as we have stages.
+    SmallVector<memref::AllocaOp> replacements;
+    OpBuilder builder(pipelineOp);
+    for ([[maybe_unused]] unsigned i : llvm::seq(pipelineOp.getStages().size()))
+      builder.insert(replacements.emplace_back(allocation.clone()));
+
+    // Find the region the allocation is contained in to find the IV we need to
+    // use for the resource cycling.
+    Region *parentRegion = allocation->getParentRegion();
+    while (parentRegion->getParentOp() != pipelineOp)
+      parentRegion = parentRegion->getParentRegion();
+    Value iv = parentRegion->getArgument(0);
+
+    // The cycle can be computed by normalizing the IV first and then
+    // performing a mod operation using our number of stages.
+    builder.setInsertionPoint(allocation);
+    Value cycle = affine::makeComposedAffineApply(
+        builder, loc,
+        builder.getAffineDimExpr(0).floorDiv(builder.getAffineDimExpr(1)) %
+            pipelineOp.getStages().size(),
+        {iv, pipelineOp.getStep()});
+
+    // Switch on the cycle number and return the corresponding resource.
+    auto switchOp = builder.create<scf::IndexSwitchOp>(
+        loc, allocation.getType(), cycle,
+        llvm::to_vector(llvm::seq<int64_t>(pipelineOp.getStages().size() - 1)),
+        pipelineOp.getStages().size() - 1);
+    for (unsigned i : llvm::seq(pipelineOp.getRegions().size())) {
+      if (i == pipelineOp.getRegions().size() - 1)
+        builder.setInsertionPointToStart(
+            &switchOp.getDefaultRegion().emplaceBlock());
+      else
+        builder.setInsertionPointToStart(
+            &switchOp.getCaseRegions()[i].emplaceBlock());
+
+      builder.create<scf::YieldOp>(loc, replacements[i].getMemref());
+    }
+
+    allocation->replaceAllUsesWith(switchOp);
+    allocation->erase();
+  });
+}
+
+/// Clones the given pipeline stage at the insertion point
+/// of builder without the yield operation.
+/// 'mapping' can be used to remap the block arguments of the block
+/// and will additionally be used to contain the result mapping.
+///
+/// Returns the operands of the yield operation had it been cloned.
+static SmallVector<Value> insertStage(OpBuilder &builder, Region &stage,
+                                      IRMapping &mapping) {
+  Block *block = &stage.front();
+  for (Operation &op : block->without_terminator())
+    builder.clone(op, mapping);
+
+  SmallVector<Value> result;
+  for (Value value : cast<PipelineYieldOp>(block->getTerminator()).getResults())
+    result.push_back(mapping.lookupOrDefault(value));
+
+  return result;
+}
+
+/// Returns the local induction value for a given stage.
+/// We separate between two kinds of induction values:
+/// * The global induction value
+/// * The local induction value of a stage
+/// The global induction value is the induction value of the first pipeline
+/// stage only.
+/// Since the second stage with IV = 0 executes at the same time as the first
+/// stage with IV = 1, a negative offset has to be applied to the global IV
+/// to map it to a given stage. This returned value is the local induction
+/// value.
+/// This function generates the code necessary that maps the global IV
+/// 'inductionVar' to the local IV of 'stage' and returns the local IV.
+/// 'step' is the step value of the pipeline op.
+static Value getInductionVarForStage(OpBuilder &builder, Region &stage,
+                                     Value inductionVar, Value step) {
+  return affine::makeComposedAffineApply(
+      builder, inductionVar.getLoc(),
+      builder.getAffineDimExpr(0) -
+          builder.getAffineDimExpr(1) *
+              builder.getAffineConstantExpr(stage.getRegionNumber()),
+      {inductionVar, step});
+}
+
+void LowerPipelineOp::runOnOperation() {
+  getOperation()->walk([&](PipelineOp pipelineOp) {
+    if (pipelineOp.hasTensorSemantics())
+      return;
+
+    makeResourceUsageExplicit(pipelineOp);
+
+    IRRewriter builder(pipelineOp);
+    Value currentIV = pipelineOp.getLowerBound();
+    SmallVector<SmallVector<Value>> oldResultsOfStages(
+        pipelineOp.getRegions().size() - 1);
+
+    // Build on-ramp that executes all stages except the last.
+    // As soon as we have started executing the last stage our pipeline is fully
+    // utilized and we can switch to the 'scf.for'.
+    for (unsigned i = 0; i < pipelineOp.getRegions().size() - 1; i++) {
+      SmallVector<SmallVector<Value>> newResultsOfStages(
+          pipelineOp.getRegions().size() - 1);
+
+      // Go over one more stage every iteration as the result of the previous
+      // stage gets ready.
+      for (Region &stage : pipelineOp->getRegions().take_front(i + 1)) {
+        IRMapping mapping;
+        mapping.map(stage.getArguments().front(),
+                    getInductionVarForStage(builder, stage, currentIV,
+                                            pipelineOp.getStep()));
+        if (stage != pipelineOp.getStages().front())
+          for (auto [oldBlockArg, newBlockArg] :
+               llvm::zip_equal(stage.getArguments().drop_front(),
+                               oldResultsOfStages[stage.getRegionNumber() - 1]))
+            mapping.map(oldBlockArg, newBlockArg);
+
+        newResultsOfStages[stage.getRegionNumber()] =
+            insertStage(builder, stage, mapping);
+      }
+
+      oldResultsOfStages = std::move(newResultsOfStages);
+      currentIV = builder.create<arith::AddIOp>(pipelineOp->getLoc(), currentIV,
+                                                pipelineOp.getStep());
+    }
+
+    SmallVector<Value> oldResultsOfStagesFlattened;
+    // Maps from the index of a stage to the index of the first value in
+    // 'oldResultsOfStagesFlattened' that is no longer part of this stages
+    // result.
+    SmallVector<size_t> endOfStageIndex{0};
+    for (ArrayRef<Value> results : oldResultsOfStages) {
+      llvm::append_range(oldResultsOfStagesFlattened, results);
+      endOfStageIndex.push_back(endOfStageIndex.back() + results.size());
+    }
+
+    auto forOp = builder.create<scf::ForOp>(
+        pipelineOp->getLoc(), currentIV, pipelineOp.getUpperBound(),
+        pipelineOp.getStep(), oldResultsOfStagesFlattened);
+    {
+      OpBuilder::InsertionGuard guard{builder};
+      builder.setInsertionPointToStart(forOp.getBody());
+
+      SmallVector<Value> newResultsOfStagesFlattened;
+      for (Region &stage : pipelineOp.getStages()) {
+        Value iv = getInductionVarForStage(
+            builder, stage, forOp.getInductionVar(), pipelineOp.getStep());
+
+        IRMapping mapping;
+        mapping.map(stage.getArguments().front(), iv);
+        if (stage != pipelineOp.getStages().front()) {
+          size_t begin = endOfStageIndex[stage.getRegionNumber() - 1];
+          size_t end = endOfStageIndex[stage.getRegionNumber()];
+          MutableArrayRef<BlockArgument> argument =
+              forOp.getRegionIterArgs().slice(begin, end - begin);
+          for (auto [oldBlockArg, newBlockArg] :
+               llvm::zip_equal(stage.getArguments().drop_front(), argument))
+            mapping.map(oldBlockArg, newBlockArg);
+        }
+        llvm::append_range(newResultsOfStagesFlattened,
+                           insertStage(builder, stage, mapping));
+      }
+      builder.create<scf::YieldOp>(pipelineOp->getLoc(),
+                                   newResultsOfStagesFlattened);
+    }
+
+    // Off-ramp.
+    for (unsigned i = 0; i < endOfStageIndex.size() - 1; i++) {
+      uint64_t begin = endOfStageIndex[i];
+      uint64_t end = endOfStageIndex[i + 1];
+      oldResultsOfStages[i] = forOp.getResults().slice(begin, end - begin);
+    }
+
+    // Compute the real inclusive UB of the IV as it'd be at the end of the
+    // 'scf.for'.
+    currentIV = affine::makeComposedAffineApply(
+        builder, pipelineOp->getLoc(),
+        builder.getAffineDimExpr(0).floorDiv(builder.getAffineDimExpr(1)) *
+            builder.getAffineDimExpr(1),
+        {forOp.getUpperBound(), forOp.getStep()});
+
+    // Paste the stages until the last stage has done its last iteration.
+    for (unsigned i = 1; i < pipelineOp.getRegions().size(); i++) {
+      SmallVector<SmallVector<Value>> newResultsOfStages(
+          pipelineOp.getRegions().size() - 1);
+
+      // One fewer stage every iteration, first stage already completed.
+      for (Region &stage : pipelineOp->getRegions().drop_front(i)) {
+        Value iv = getInductionVarForStage(builder, stage, currentIV,
+                                           pipelineOp.getStep());
+
+        IRMapping mapping;
+        mapping.map(stage.getArguments().front(), iv);
+        for (auto [oldBlockArg, newBlockArg] :
+             llvm::zip_equal(stage.getArguments().drop_front(),
+                             oldResultsOfStages[stage.getRegionNumber() - 1]))
+          mapping.map(oldBlockArg, newBlockArg);
+
+        if (stage != pipelineOp.getStages().back())
+          newResultsOfStages[stage.getRegionNumber()] =
+              insertStage(builder, stage, mapping);
+        else
+          insertStage(builder, stage, mapping);
+      }
+      oldResultsOfStages = std::move(newResultsOfStages);
+      currentIV = builder.create<arith::AddIOp>(pipelineOp->getLoc(), currentIV,
+                                                pipelineOp.getStep());
+    }
+
+    pipelineOp->erase();
+  });
+}

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
@@ -45,6 +45,12 @@ def LowerL1AllocationsPass : InterfacePass<"quidditch-lower-l1-allocations",
   ];
 }
 
+def LowerPipelineOpPass : Pass<"quidditch-lower-pipeline-op"> {
+  let dependentDialects = [
+    "mlir::scf::SCFDialect",
+  ];
+}
+
 def SpecializeDMACodePass : Pass<"quidditch-specialize-dma-code",
   "mlir::ModuleOp"> {
 

--- a/codegen/tests/Dialect/Snitch/Transforms/lower-pipeline.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/lower-pipeline.mlir
@@ -1,0 +1,72 @@
+// RUN: quidditch-opt %s --quidditch-lower-pipeline-op | FileCheck %s
+
+// CHECK-DAG: #[[$MAP0:.*]] = affine_map<() -> (0)>
+// CHECK-DAG: #[[$MAP1:.*]] = affine_map<([[D0:.*]]) -> (([[D0]] floordiv 40) mod 2)>
+// CHECK-DAG: #[[$MAP2:.*]] = affine_map<([[D0:.*]]) -> ([[D0]])>
+// CHECK-DAG: #[[$MAP3:.*]] = affine_map<([[D0:.*]]) -> ([[D0]] - 40)>
+// CHECK-DAG: #[[$MAP4:.*]] = affine_map<() -> (1200)>
+// CHECK-DAG: #[[$MAP5:.*]] = affine_map<() -> (1160)>
+
+// CHECK-LABEL: @test
+func.func @test(
+  %arg0 : index,
+  %9 : memref<1200x400xf64, strided<[400, 1], offset: ?>>,
+  %alloca : memref<1x1200xf64, #quidditch_snitch.l1_encoding>,
+  %alloca2 : memref<1x100xf64, #quidditch_snitch.l1_encoding>,
+  %out : memref<1x40xf64, #quidditch_snitch.l1_encoding>
+) {
+  // CHECK-DAG: %[[LB:.*]] = arith.constant 0
+  // CHECK-DAG: %[[UB:.*]] = arith.constant 1200
+  // CHECK-DAG: %[[STEP:.*]] = arith.constant 40
+  %c0 = arith.constant 0 : index
+  %c1200 = arith.constant 1200 : index
+  %c40 = arith.constant 40 : index
+
+  // CHECK: %[[ALLOCA0:.*]] = memref.alloca()
+  // CHECK: %[[ALLOCA1:.*]] = memref.alloca()
+
+  // Stage 0 ramp up.
+  // CHECK: %[[IV:.*]] = affine.apply #[[$MAP0]]()
+  // CHECK: memref.subview %{{.*}}[%[[IV]], %{{.*}}]
+  // CHECK: %[[CYCLE:.*]] = affine.apply #[[$MAP1]](%[[IV]])
+  // CHECK: %[[ALLOCA:.*]] = scf.index_switch %[[CYCLE]]
+  // CHECK-NEXT: case 0
+  // CHECK-NEXT: yield %[[ALLOCA0]]
+  // CHECK: default
+  // CHECK-NEXT: yield %[[ALLOCA1]]
+  // CHECK: %[[TOKEN:.*]] = quidditch_snitch.start_dma_transfer from %{{.*}} to %[[ALLOCA]]
+
+  // Full pipeline.
+  // CHECK: %[[NEW_LB:.*]] = arith.addi %[[LB]], %[[STEP]]
+  // CHECK: %[[LAST:.*]]:2 = scf.for %[[IV:.*]] = %[[NEW_LB]] to %[[UB]] step %[[STEP]] iter_args(%[[YIELDED0:.*]] = %[[ALLOCA]], %[[YIELDED1:.*]] = %[[TOKEN]])
+  quidditch_snitch.pipeline %c0 to %c1200 step %c40 {
+  ^bb0(%arg1: index):
+    // CHECK: %[[STAGE0_IV:.*]] = affine.apply #[[$MAP2]](%[[IV]])
+    // CHECK: memref.subview %{{.*}}[%[[STAGE0_IV]], %{{.*}}]
+    // CHECK: %[[NEXT_YIELDED:.*]] = scf.index_switch
+
+    %subview_3 = memref.subview %9[%arg1, %arg0] [40, 100] [1, 1] : memref<1200x400xf64, strided<[400, 1], offset: ?>> to memref<40x100xf64, strided<[400, 1], offset: ?>>
+    %alloca_4 = memref.alloca() {alignment = 64 : i64} : memref<40x100xf64, #quidditch_snitch.l1_encoding>
+    %16 = quidditch_snitch.start_dma_transfer from %subview_3 : memref<40x100xf64, strided<[400, 1], offset: ?>> to %alloca_4 : memref<40x100xf64, #quidditch_snitch.l1_encoding>
+    quidditch_snitch.pipeline_yield %alloca_4, %16 : memref<40x100xf64, #quidditch_snitch.l1_encoding>, !quidditch_snitch.dma_token
+  }, {
+  ^bb0(%arg1: index, %arg2: memref<40x100xf64, #quidditch_snitch.l1_encoding>, %arg3: !quidditch_snitch.dma_token):
+    // CHECK: %[[STAGE1_IV:.*]] = affine.apply #[[$MAP3]](%[[IV]])
+    // CHECK: memref.subview %{{.*}}[0, %[[STAGE1_IV]]]
+    // CHECK: wait_for_dma_transfers %[[YIELDED1]]
+    // CHECK: linalg.matmul_transpose_b ins(%{{.*}}, %[[YIELDED0]] : {{.*}})
+    // CHECK: yield %[[NEXT_YIELDED]], %{{.*}} :
+
+    %subview_3 = memref.subview %alloca[0, %arg1] [1, 40] [1, 1] : memref<1x1200xf64, #quidditch_snitch.l1_encoding> to memref<1x40xf64, strided<[1200, 1], offset: ?>, #quidditch_snitch.l1_encoding>
+    quidditch_snitch.wait_for_dma_transfers %arg3 : !quidditch_snitch.dma_token
+    linalg.matmul_transpose_b
+      ins(%alloca2, %arg2 : memref<1x100xf64, #quidditch_snitch.l1_encoding>, memref<40x100xf64, #quidditch_snitch.l1_encoding>)
+      outs(%out : memref<1x40xf64, #quidditch_snitch.l1_encoding>)
+  }
+  // CHECK: %[[IV:.*]] = affine.apply #[[$MAP4]]()
+  // CHECK: %[[STAGE1_IV:.*]] = affine.apply #[[$MAP5]]()
+  // CHECK: memref.subview %{{.*}}[0, %[[STAGE1_IV]]]
+  // CHECK: wait_for_dma_transfers %[[LAST]]#1
+  // CHECK: linalg.matmul_transpose_b ins(%{{.*}}, %[[LAST]]#0 : {{.*}})
+  return
+}


### PR DESCRIPTION
This PR implements the lowering of bufferized `pipeline` operations to standard set of dialects. The lowering itself does not introduce any concurrency but rather relies on the stages to start and wait for concurrent operations.

It starts of by generating a "ramp up", which pastes all stages after each other until the last stage could start executing. It then enters the hot loop which is a single `scf.for` that executes every pipeline stage after another, albeit with a different IV for each. After the core `scf.for` a ramp down makes sure that later stages consume the results of the previous stages that were still executed within the `scf.for`.

The only limitation of the lowering is that it currently requires the loop to execute at least "numStages - 1" many times. Otherwise, UB occurs.