### PR TITLE
[quidditch_snitch] Implement `pipeline-copy-compute` pass

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
@@ -52,13 +52,15 @@ def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
 
   let parameters = (ins
     TileSizeList:$workgroup_tiles,
-    TileSizeList:$l1_tiles
+    TileSizeList:$l1_tiles,
+    DefaultValuedParameter<"bool", "false">:$dual_buffer
   );
 
   let builders = [
     AttrBuilder<(ins
       CArg<"llvm::ArrayRef<int64_t>", "{}">:$workgroupTiles,
-      CArg<"llvm::ArrayRef<int64_t>", "{}">:$l1Tiles
+      CArg<"llvm::ArrayRef<int64_t>", "{}">:$l1Tiles,
+      CArg<"bool", "false">:$dualBuffer
     )>
   ];
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
@@ -31,9 +31,10 @@ static ArrayRef<int64_t> dropTrailingZeros(ArrayRef<int64_t> array) {
 
 LoweringConfigAttr LoweringConfigAttr::get(MLIRContext *context,
                                            ArrayRef<int64_t> workgroupTiles,
-                                           ArrayRef<int64_t> l1Tiles) {
+                                           ArrayRef<int64_t> l1Tiles,
+                                           bool dualBuffer) {
   return Base::get(context, dropTrailingZeros(workgroupTiles),
-                   dropTrailingZeros(l1Tiles));
+                   dropTrailingZeros(l1Tiles), dualBuffer);
 }
 
 //===----------------------------------------------------------------------===//

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
         "LowerForallOp.cpp"
         "LowerL1Allocations.cpp"
         "LowerPipelineOp.cpp"
+        "PipelineCopyCompute.cpp"
         "PromoteToL1.cpp"
         "SpecializeDMACode.cpp"
         DEPS

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/Passes.td
@@ -74,4 +74,10 @@ def LowerForallOpPass : Pass<"quidditch-lower-forall-op"> {
   ];
 }
 
+def PipelineCopyComputePass : Pass<"quidditch-pipeline-copy-compute"> {
+  let dependentDialects = [
+    "quidditch::Snitch::QuidditchSnitchDialect",
+  ];
+}
+
 #endif

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PipelineCopyCompute.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/PipelineCopyCompute.cpp
@@ -1,0 +1,177 @@
+#include "Passes.h"
+
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.h"
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Interfaces/TilingInterface.h"
+
+namespace quidditch::Snitch {
+#define GEN_PASS_DEF_PIPELINECOPYCOMPUTEPASS
+#include "Quidditch/Dialect/Snitch/Transforms/Passes.h.inc"
+} // namespace quidditch::Snitch
+
+namespace {
+class PipelineCopyCompute
+    : public quidditch::Snitch::impl::PipelineCopyComputePassBase<
+          PipelineCopyCompute> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+
+} // namespace
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+using namespace quidditch::Snitch;
+
+/// Lifts an 'scf.for' op to a pipeline op with two stages.
+/// The body of the for loop gets placed in the second stage with all iter args
+/// forwarded from the first to the second stage.
+static PipelineOp liftToPipeline(scf::ForOp forOp) {
+  OpBuilder builder(forOp);
+  auto toIndex = [&](Value value) -> Value {
+    if (isa<IndexType>(value.getType()))
+      return value;
+    return builder.create<arith::IndexCastOp>(value.getLoc(),
+                                              builder.getIndexType(), value);
+  };
+  auto pipelineOp = builder.create<PipelineOp>(
+      forOp.getLoc(), forOp->getResultTypes(), toIndex(forOp.getLowerBound()),
+      toIndex(forOp.getUpperBound()), toIndex(forOp.getStep()),
+      forOp.getInitArgs(),
+      /*numRegions=*/2);
+
+  Region &copyRegion = pipelineOp.getStages()[0];
+  Region &computeRegion = pipelineOp.getStages()[1];
+  computeRegion.takeBody(forOp.getRegion());
+  {
+    OpBuilder::InsertionGuard guard{builder};
+    Block &singleBlock = computeRegion.front();
+    builder.setInsertionPointToEnd(&singleBlock);
+    auto yieldOp = cast<scf::YieldOp>(singleBlock.getTerminator());
+    builder.create<PipelineYieldOp>(yieldOp.getLoc(), yieldOp.getResults());
+    yieldOp->erase();
+  }
+  {
+    OpBuilder::InsertionGuard guard{builder};
+
+    builder.setInsertionPointToStart(&copyRegion.emplaceBlock());
+    copyRegion.addArguments(computeRegion.getArgumentTypes(),
+                            llvm::map_to_vector(computeRegion.getArguments(),
+                                                std::mem_fn(&Value::getLoc)));
+    // Don't yield the induction variable.
+    builder.create<PipelineYieldOp>(pipelineOp.getLoc(),
+                                    copyRegion.getArguments().drop_front());
+  }
+  return pipelineOp;
+}
+
+static void pipelineForLoop(scf::ForOp forOp) {
+  // Compute the set of operations that we want to move into the first stage,
+  // the copy stage, by calculating the backward slice from the
+  // 'wait_for_tensor_copy' operation. The wait operation will remain in the
+  // compute stage.
+  SetVector<Operation *> toMove;
+  for (auto computeOp : forOp.getOps<TilingInterface>()) {
+    BackwardSliceOptions options;
+    options.omitBlockArguments = true;
+    options.inclusive = true;
+    options.filter = [&](Operation *op) {
+      return op->getParentRegion() == &forOp.getRegion();
+    };
+
+    for (Value operand : computeOp->getOperands()) {
+      // TODO: This assumes the immediate operand of the compute op is the
+      //       wait operation rather than starting the backwards slice after the
+      //       wait operation. Ideally we should first do one backward slice to
+      //       discover the wait operations, then do the backward slice on its
+      //       transfer tensor.
+      auto tensorCopyWait = operand.getDefiningOp<WaitForTensorCopyOp>();
+      if (!tensorCopyWait)
+        continue;
+
+      // Ignore if outside the for loop.
+      if (tensorCopyWait->getParentRegion() != forOp.getRegion())
+        continue;
+
+      if (isa<BlockArgument>(tensorCopyWait.getTransferTensor()))
+        continue;
+
+      getBackwardSlice(tensorCopyWait.getTransferTensor(), &toMove, options);
+    }
+  }
+  if (!llvm::all_of(toMove, isPure))
+    return;
+
+  PipelineOp pipelineOp = liftToPipeline(forOp);
+  forOp.replaceAllUsesWith(pipelineOp.getResults());
+  forOp->erase();
+
+  // Move the copy operations into the copy region.
+  Region &copyRegion = pipelineOp.getStages()[0];
+  Region &computeRegion = pipelineOp.getStages()[1];
+  auto copyRegionBuilder = OpBuilder::atBlockBegin(&copyRegion.front());
+  for (Operation *op : toMove) {
+    op->remove();
+    copyRegionBuilder.insert(op);
+    // Make sure to remap the induction variable from the one of the compute
+    // region to the copy region.
+    for (OpOperand &operand : op->getOpOperands())
+      if (auto blockArg = dyn_cast<BlockArgument>(operand.get()))
+        if (blockArg.getParentRegion() == &computeRegion)
+          operand.set(copyRegion.getArgument(blockArg.getArgNumber()));
+  }
+
+  // Fix up any uses in the compute region that are defined in the copy region.
+  // On the first occurrence of such a use, we yield the value and rewrite the
+  // use to a new corresponding block argument in the compute region.
+  PipelineYieldOp copyRegionYield =
+      cast<PipelineYieldOp>(pipelineOp.getStages()[0].front().getTerminator());
+  for (Operation *op : toMove) {
+    for (OpResult result : op->getResults()) {
+      BlockArgument replacement;
+      for (OpOperand &use : llvm::make_early_inc_range(result.getUses())) {
+        // Skip uses in the copy region.
+        if (copyRegion.isAncestor(use.getOwner()->getParentRegion()))
+          continue;
+
+        if (!replacement) {
+          replacement =
+              computeRegion.addArgument(result.getType(), op->getLoc());
+          copyRegionYield.getResultsMutable().append(result);
+        }
+        use.set(replacement);
+      }
+    }
+  }
+}
+
+void PipelineCopyCompute::runOnOperation() {
+  // Collect surrounding for loops of ops that requested to be multi buffered.
+  SetVector<scf::ForOp> toPipeline;
+  getOperation()->walk([&](TilingInterface computeOp) {
+    auto config = getLoweringConfig<LoweringConfigAttr>(computeOp);
+    if (!config)
+      return;
+
+    if (!config.getDualBuffer())
+      return;
+
+    // TODO: This creates an uncomfortably tight coupling between the
+    //  pass pipeline and tiling and the dual buffering.
+    auto forOp = dyn_cast<scf::ForOp>(computeOp->getParentOp());
+    if (!forOp ||
+        !llvm::all_of(forOp.getResultTypes(), llvm::IsaPred<RankedTensorType>))
+      return;
+
+    toPipeline.insert(forOp);
+  });
+
+  llvm::for_each(toPipeline, pipelineForLoop);
+}

--- a/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
+++ b/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
@@ -57,6 +57,7 @@ static LogicalResult setRootConfig(FunctionOpInterface funcOp,
         //   only applicable once on Occamy.
         SmallVector<int64_t> workgroupTiles(3, 0);
         SmallVector<int64_t> l1Tiles(3, 0);
+        bool dualBuffer = false;
 
         if (funcOp.getName() ==
             "main$async_dispatch_0_matmul_transpose_b_1x400x161_f64") {
@@ -65,31 +66,34 @@ static LogicalResult setRootConfig(FunctionOpInterface funcOp,
         }
         if (funcOp.getName() ==
             "main$async_dispatch_7_matmul_transpose_b_1x600x400_f64") {
-          workgroupTiles[2] = 200;
+          workgroupTiles[2] = 100;
 
           l1Tiles[0] = 0;
           l1Tiles[1] = 40;
           l1Tiles[2] = 0;
+          dualBuffer = true;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_8_matmul_transpose_b_1x600x600_f64") {
-          workgroupTiles[2] = 200;
+          workgroupTiles[2] = 100;
 
           l1Tiles[0] = 0;
           l1Tiles[1] = 40;
+          dualBuffer = true;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_1_matmul_transpose_b_1x1200x400_f64") {
-          workgroupTiles[2] = 200;
+          workgroupTiles[2] = 100;
 
           l1Tiles[0] = 0;
           l1Tiles[1] = 40;
           l1Tiles[2] = 0;
+          dualBuffer = true;
         }
 
-        setLoweringConfig(rootOp,
-                          quidditch::Snitch::LoweringConfigAttr::get(
-                              rootOp->getContext(), workgroupTiles, l1Tiles));
+        setLoweringConfig(rootOp, quidditch::Snitch::LoweringConfigAttr::get(
+                                      rootOp->getContext(), workgroupTiles,
+                                      l1Tiles, dualBuffer));
         return success();
       })
       .Default(success());

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -191,6 +191,7 @@ public:
           return quidditch::createTensorTilePass({quidditch::TilingLevel::L1});
         })
         .addPass(quidditch::Snitch::createPromoteOperandsToL1Pass)
+        .addPass(quidditch::Snitch::createPipelineCopyComputePass)
         // TODO: Fuse scf.forall after.
         .addPass([] {
           return quidditch::createTensorTilePass(
@@ -227,7 +228,12 @@ public:
     addIREEPostBufferizationPasses(modulePassManager.nest<func::FuncOp>());
 
     FunctionLikeNest(modulePassManager)
+        .addPass(quidditch::Snitch::createLowerPipelineOpPass)
         .addPass(quidditch::Snitch::createLowerForallOpPass)
+        .addPass(createSCFForLoopCanonicalizationPass)
+        .addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
+        .addPass(createCanonicalizerPass)
         // TODO: Remove the following pass and plumb support for
         // #hal.descriptor_type memory space through the stack.
         .addPass(createEraseHALDescriptorTypeFromMemRefPass)

--- a/codegen/tests/Dialect/Snitch/Transforms/pipeline-copy-compute.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/pipeline-copy-compute.mlir
@@ -1,0 +1,60 @@
+// RUN: quidditch-opt %s -p "builtin.module(func.func(quidditch-pipeline-copy-compute))" | FileCheck %s
+
+// CHECK-LABEL: @test
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG2:[[:alnum:]]+]]
+func.func @test(%arg0: index, %extracted_slice : tensor<1x100xf64>, %14 : tensor<1200x400xf64>) -> tensor<1x1200xf64> {
+  // CHECK-DAG: %[[C0:.*]] = arith.constant 0
+  // CHECK-DAG: %[[C40:.*]] = arith.constant 40
+  // CHECK-DAG: %[[C1200:.*]] = arith.constant 1200
+  %c0 = arith.constant 0 : index
+  %c40 = arith.constant 40 : index
+  %c1200 = arith.constant 1200 : index
+  // CHECK: %[[EMPTY:.*]] = tensor.empty()
+  %arg1 = tensor.empty() : tensor<1x1200xf64>
+  // CHECK: pipeline %[[C0]] to %[[C1200]] step %[[C40]] inits(%[[EMPTY]])
+  %24 = scf.for %arg2 = %c0 to %c1200 step %c40 iter_args(%arg3 = %arg1) -> (tensor<1x1200xf64>) {
+    // CHECK: ^{{.*}}(%[[IV:.*]]: index, %[[ITER:[[:alnum:]]+]]:
+    // CHECK: %[[RESULT0:.*]], %[[TOKEN0:.*]] = quidditch_snitch.start_tensor_copy %[[ARG1]]
+    // CHECK: %[[SLICE1:.*]] = tensor.extract_slice %[[ARG2]][%[[IV]], %[[ARG0]]]
+    // CHECK: %[[RESULT1:.*]], %[[TOKEN1:.*]] = quidditch_snitch.start_tensor_copy %[[SLICE1]]
+    // CHECK: %[[SLICE2:.*]] = tensor.extract_slice %[[ITER]][0, %[[IV]]]
+    // CHECK: %[[RESULT2:.*]], %[[TOKEN2:.*]] = quidditch_snitch.start_tensor_copy %[[SLICE2]]
+    // CHECK: pipeline_yield %[[ITER]], %[[RESULT0:.*]], %[[TOKEN0]], %[[SLICE1]], %[[RESULT1]], %[[TOKEN1]], %[[SLICE2]], %[[RESULT2]], %[[TOKEN2]]
+
+    %extracted_slice_6 = tensor.extract_slice %14[%arg2, %arg0] [40, 100] [1, 1] : tensor<1200x400xf64> to tensor<40x100xf64>
+    %extracted_slice_7 = tensor.extract_slice %arg3[0, %arg2] [1, 40] [1, 1] : tensor<1x1200xf64> to tensor<1x40xf64>
+    %result_8, %token_9 = quidditch_snitch.start_tensor_copy %extracted_slice to L1 : tensor<1x100xf64>
+    %25 = quidditch_snitch.wait_for_tensor_copy of %extracted_slice to %result_8 using %token_9 : tensor<1x100xf64>
+    %result_10, %token_11 = quidditch_snitch.start_tensor_copy %extracted_slice_6 to L1 : tensor<40x100xf64>
+    %26 = quidditch_snitch.wait_for_tensor_copy of %extracted_slice_6 to %result_10 using %token_11 : tensor<40x100xf64>
+    %result_12, %token_13 = quidditch_snitch.start_tensor_copy %extracted_slice_7 to L1 : tensor<1x40xf64>
+    %27 = quidditch_snitch.wait_for_tensor_copy of %extracted_slice_7 to %result_12 using %token_13 : tensor<1x40xf64>
+
+    // CHECK: ^{{.*}}(
+    // CHECK-SAME: %[[IV:[[:alnum:]]+]]
+    // CHECK-SAME: %[[ITER:[[:alnum:]]+]]
+    // CHECK-SAME: %[[RESULT0:[[:alnum:]]+]]
+    // CHECK-SAME: %[[TOKEN0:[[:alnum:]]+]]
+    // CHECK-SAME: %[[SLICE1:[[:alnum:]]+]]
+    // CHECK-SAME: %[[RESULT1:[[:alnum:]]+]]
+    // CHECK-SAME: %[[TOKEN1:[[:alnum:]]+]]
+    // CHECK-SAME: %[[SLICE2:[[:alnum:]]+]]
+    // CHECK-SAME: %[[RESULT2:[[:alnum:]]+]]
+    // CHECK-SAME: %[[TOKEN2:[[:alnum:]]+]]
+    // CHECK: %[[OPA:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[ARG1]] to %[[RESULT0]] using %[[TOKEN0]]
+    // CHECK: %[[OPB:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[SLICE1]] to %[[RESULT1]] using %[[TOKEN1]]
+    // CHECK: %[[OPC:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[SLICE2]] to %[[RESULT2]] using %[[TOKEN2]]
+    // CHECK: %[[RES:.*]] = linalg.matmul_transpose_b
+    // CHECK-SAME: ins(%[[OPA]], %[[OPB]] :
+    // CHECK-SAME: outs(%[[OPC]] :
+    // CHECK: %[[YIELDED:.*]] = tensor.insert_slice %[[RES]] into %[[ITER]]
+    // CHECK: pipeline_yield %[[YIELDED]]
+
+    %28 = linalg.matmul_transpose_b {lowering_config = #quidditch_snitch.lowering_config<workgroup_tiles = [0, 0, 100], l1_tiles = [0, 40], dual_buffer = true>} ins(%25, %26 : tensor<1x100xf64>, tensor<40x100xf64>) outs(%27 : tensor<1x40xf64>) -> tensor<1x40xf64>
+    %inserted_slice = tensor.insert_slice %28 into %arg3[0, %arg2] [1, 40] [1, 1] : tensor<1x40xf64> into tensor<1x1200xf64>
+    scf.yield %inserted_slice : tensor<1x1200xf64>
+  }
+  return %24 : tensor<1x1200xf64>
+}


### PR DESCRIPTION
This PR implements the lifting of `scf.for` ops containing a compute op + tensor copy ops into a `pipeline` op where copy and compute operations are split into two pipeline stages. An additional `dual_buffer` attribute on the lowering config of the compute op controls whether this should be performed (which it almost should be). This also updates our configs and pipeline to perform dual buffering of the rows of the matrix.