### PR TITLE
[LowerL1Allocations] Support non-identity strides in L1 `memref.alloca`

### DIFF
--- a/codegen/tests/Dialect/Snitch/Transforms/lower-l1-allocations.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/lower-l1-allocations.mlir
@@ -1,16 +1,24 @@
 // RUN: quidditch-opt %s -p "builtin.module(func.func(quidditch-lower-l1-allocations))" | FileCheck %s
 
 // CHECK-LABEL: @test()
-// CHECK-SAME: -> (memref<32xf32>, memref<64xf64>)
+// CHECK-SAME: -> (memref<32xf32>, memref<2x64xf64, strided<[65, 1]>>)
 func.func @test() -> (memref<32xf32, #quidditch_snitch.l1_encoding>,
-                      memref<64xf64, #quidditch_snitch.l1_encoding>) {
+                      memref<2x64xf64, strided<[65, 1]>, #quidditch_snitch.l1_encoding>) {
   // CHECK: %[[VIEW:.*]] = quidditch_snitch.l1_memory_view
   // CHECK: %[[OFFSET:.*]] = arith.constant 0
-  // CHECK: %[[ALLOCA0:.*]] = memref.view %[[VIEW]][%[[OFFSET]]][] : memref<{{.*}}xi8> to memref<32xf32>
+  // CHECK: %[[VIEW0:.*]] = memref.view %[[VIEW]][%[[OFFSET]]][] : memref<{{.*}}xi8> to memref<32xf32>
+  // CHECK: %[[ALLOCA0:.*]] = memref.reinterpret_cast %[[VIEW0]]
+  // CHECK-SAME: offset: [0]
+  // CHECK-SAME: sizes: [32]
+  // CHECK-SAME: strides: [1]
   %0 = memref.alloca() : memref<32xf32, #quidditch_snitch.l1_encoding>
   // CHECK: %[[OFFSET:.*]] = arith.constant 128
-  // CHECK: %[[ALLOCA1:.*]] = memref.view %[[VIEW]][%[[OFFSET]]][] : memref<{{.*}}xi8> to memref<64xf64>
-  %1 = memref.alloca() : memref<64xf64, #quidditch_snitch.l1_encoding>
+  // CHECK: %[[VIEW1:.*]] = memref.view %[[VIEW]][%[[OFFSET]]][] : memref<{{.*}}xi8> to memref<129xf64>
+  // CHECK: %[[ALLOCA1:.*]] = memref.reinterpret_cast %[[VIEW1]]
+  // CHECK-SAME: offset: [0]
+  // CHECK-SAME: sizes: [2, 64]
+  // CHECK-SAME: strides: [65, 1]
+  %1 = memref.alloca() : memref<2x64xf64, strided<[65, 1]>, #quidditch_snitch.l1_encoding>
   // CHECK: return %[[ALLOCA0]], %[[ALLOCA1]]
-  return %0, %1 : memref<32xf32, #quidditch_snitch.l1_encoding>, memref<64xf64, #quidditch_snitch.l1_encoding>
+  return %0, %1 : memref<32xf32, #quidditch_snitch.l1_encoding>, memref<2x64xf64, strided<[65, 1]>, #quidditch_snitch.l1_encoding>
 }


### PR DESCRIPTION
The previous lowering would crash in this case as `memref.view` op does not support a non-identity result `memref`. This PR fixes the lowering by first creating a `view` into a buffer with enough elements to support a given layout (i.e. includes padding) before `reinterpret_cast`ing to the original layout of the `alloca`.