### PR TITLE
[samples] Speed up simulation by importing buffers

### DIFF
--- a/runtime/samples/nsnet2/nsnet2_util.c
+++ b/runtime/samples/nsnet2/nsnet2_util.c
@@ -14,7 +14,7 @@ int run_nsnet2_experiment(
     iree_hal_executable_library_query_fn_t implementation) {
   if (!snrt_is_dm_core()) return quidditch_dispatch_enter_worker_loop();
 
-  double(*data)[161] = malloc(161 * sizeof(double));
+  double(*data)[161] = aligned_alloc(64, 161 * sizeof(double));
 
   for (int i = 0; i < IREE_ARRAYSIZE(*data); i++) {
     (*data)[i] = (i + 1);

--- a/runtime/samples/util/run_model.h
+++ b/runtime/samples/util/run_model.h
@@ -24,7 +24,8 @@ typedef struct {
 
   /// Number of input tensors.
   iree_host_size_t num_inputs;
-  /// Input tensor data in dense row major encoding.
+  /// Input tensor data in dense row major encoding. Must be aligned to 64
+  /// bytes.
   const void** input_data;
   /// Number of elements for each input in 'input_data'.
   const iree_host_size_t* input_sizes;

--- a/runtime/samples/vec_multiply/main.c
+++ b/runtime/samples/vec_multiply/main.c
@@ -6,7 +6,7 @@
 #include <util/run_model.h>
 
 int main() {
-  double data[4];
+  iree_alignas(64) double data[4];
   if (!snrt_is_dm_core()) return quidditch_dispatch_enter_worker_loop();
 
   for (int i = 0; i < IREE_ARRAYSIZE(data); i++) {


### PR DESCRIPTION
This avoids allocating and then copying the input data. Mostly useful in short running tests where the VM overhead dominates.