### PR TITLE
[SpecializeDMACode] Properly lower `compute_core_index`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -235,8 +235,15 @@ def QuidditchSnitch_BarrierOp : QuidditchSnitch_Op<"barrier"> {
   }];
 }
 
-def QuidditchSnitch_ClusterIndexOp
-  : QuidditchSnitch_Op<"cluster_index", [Pure]> {
+def QuidditchSnitch_ComputeCoreIndexOp
+  : QuidditchSnitch_Op<"compute_core_index", [Pure]> {
+
+  let description = [{
+    Returns the index of the compute core within a given cluster.
+    This is guaranteed to return a number between 0 and exclusive
+    `compute_cores` where `compute_cores` is an `IntegerAttr` in
+    the surrounding `ExecutableTargetAttr`.
+  }];
 
   let results = (outs Index:$result);
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerForallOp.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerForallOp.cpp
@@ -44,7 +44,7 @@ void LowerForallOp::runOnOperation() {
     forallOp.getTerminator().erase();
 
     OpBuilder builder(forallOp);
-    Value id = builder.create<ClusterIndexOp>(forallOp.getLoc());
+    Value id = builder.create<ComputeCoreIndexOp>(forallOp.getLoc());
 
     Value lb = forallOp.getLowerBound(builder).front();
     Value ub = forallOp.getUpperBound(builder).front();

--- a/codegen/compiler/src/Quidditch/Target/RemoveTrivialLoops.cpp
+++ b/codegen/compiler/src/Quidditch/Target/RemoveTrivialLoops.cpp
@@ -30,8 +30,8 @@ static std::optional<std::pair<AffineExpr, AffineExpr>>
 getWorkgroupRange(Value processorValue,
                   std::optional<IntegerAttr> numComputeCores,
                   ArrayRef<int64_t> workgroupCount) {
-  if (auto idOp =
-          processorValue.getDefiningOp<quidditch::Snitch::ClusterIndexOp>()) {
+  if (auto idOp = processorValue
+                      .getDefiningOp<quidditch::Snitch::ComputeCoreIndexOp>()) {
     if (!numComputeCores)
       return std::nullopt;
 

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/compute_core_index.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/compute_core_index.mlir
@@ -3,6 +3,6 @@
 // CHECK-LABEL: @test
 func.func private @test() -> index {
   // CHECK: call @snrt_cluster_core_idx()
-  %0 = quidditch_snitch.cluster_index
+  %0 = quidditch_snitch.compute_core_index
   return %0 : index
 }

--- a/codegen/tests/Dialect/Snitch/Transforms/lower-forall.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/lower-forall.mlir
@@ -13,7 +13,7 @@ hal.executable @test {
       // CHECK-SAME: %[[UB:[[:alnum:]]+]]
       // CHECK-SAME: %[[STEP:[[:alnum:]]+]]
       func.func @test(%lb : index, %ub : index, %step : index) {
-        // CHECK: %[[ID:.*]] = quidditch_snitch.cluster_index
+        // CHECK: %[[ID:.*]] = quidditch_snitch.compute_core_index
         // CHECK: %[[NLB:.*]] = affine.apply #[[$MAP1]](%[[LB]], %[[ID]], %[[STEP]])
         // CHECK: %[[NSTEP:.*]] = affine.apply #[[$MAP2]](%[[STEP]])
         // CHECK: scf.for %[[IV:.*]] = %[[NLB]] to %[[UB]] step %[[NSTEP]]

--- a/codegen/tests/Target/remove-trivial-loops.mlir
+++ b/codegen/tests/Target/remove-trivial-loops.mlir
@@ -7,7 +7,7 @@ hal.executable @test {
     builtin.module {
       // CHECK-LABEL: func @test
       func.func @test() {
-        %0 = quidditch_snitch.cluster_index
+        %0 = quidditch_snitch.compute_core_index
         %1 = arith.constant 8 : index
         // CHECK-NOT: scf.for
         scf.for %arg3 = %0 to %1 step %1 {


### PR DESCRIPTION
Barriers may be inserted in a loop resulting from the lowering of a `scf.forall`. The lowering of `compute_core_index` unfortunately returns `num_compute_cores + 1` which is outside the specified range of the operation and leads to such loops and their barriers being skipped by the DMA core. As the pass already assumes non-divergent control flow, we can fix this by specializing `compute_core_index` to any integer in the defined range of the op.