### PR TITLE
[quidditch_snitch] Add `CompletedTokenAttr`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
@@ -8,6 +8,16 @@ include "mlir/IR/AttrTypeBase.td"
 class QuidditchSnitch_Attr<string name, list<Trait> traits = []> :
   AttrDef<QuidditchSnitch_Dialect, name, traits>;
 
+def QuidditchSnitch_CompletedTokenAttr : QuidditchSnitch_Attr<"CompletedToken"> {
+
+  let mnemonic = "completed_token";
+
+  let description = [{
+    Attribute representing an instance of a `!quidditch_snitch.dma_token`
+    signaling a complete transfer.
+  }];
+}
+
 def QuidditchSnitch_L1EncodingAttr : QuidditchSnitch_Attr<"L1Encoding"> {
   let mnemonic = "l1_encoding";
 

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
@@ -55,3 +55,13 @@ void QuidditchSnitchDialect::initialize() {
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchTypes.cpp.inc"
       >();
 }
+
+Operation *QuidditchSnitchDialect::materializeConstant(OpBuilder &builder,
+                                                       Attribute value,
+                                                       Type type,
+                                                       Location loc) {
+  if (isa<CompletedTokenAttr>(value))
+    return builder.create<CompletedTokenOp>(loc);
+
+  return nullptr;
+}

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.td
@@ -15,6 +15,7 @@ def QuidditchSnitch_Dialect : Dialect {
 
   let useDefaultAttributePrinterParser = 1;
   let useDefaultTypePrinterParser = 1;
+  let hasConstantMaterializer = 1;
 }
 
 #endif

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -190,6 +190,8 @@ def QuidditchSnitch_StartTensorCopyOp : QuidditchSnitch_Op<"start_tensor_copy",
   let assemblyFormat = [{
     $copy `to` `L1` `:` type($copy) attr-dict
   }];
+
+  let hasFolder = 1;
 }
 
 def QuidditchSnitch_WaitForTensorCopyOp : QuidditchSnitch_Op<"wait_for_tensor_copy",
@@ -228,6 +230,8 @@ def QuidditchSnitch_WaitForTensorCopyOp : QuidditchSnitch_Op<"wait_for_tensor_co
   let assemblyFormat = [{
     `of` $copy `to` $transfer_tensor `using` $token `:` type($transfer_tensor) attr-dict
   }];
+
+  let hasFolder = 1;
 }
 
 def FlatI8MemRef : ConfinedType<MemRefOf<[I8]>, [HasStaticShapePred,
@@ -267,7 +271,7 @@ def QuidditchSnitch_StartDMATransferOp : QuidditchSnitch_Op<"start_dma_transfer"
     `from` $source `:` type($source) `to` $dest `:` type($dest) attr-dict
   }];
 
-  let hasCanonicalizeMethod = 1;
+  let hasFolder = 1;
 }
 
 def QuidditchSnitch_WaitForDMATransfersOp
@@ -290,7 +294,7 @@ def QuidditchSnitch_WaitForDMATransfersOp
 }
 
 def QuidditchSnitch_CompletedTokenOp
-  : QuidditchSnitch_Op<"completed_token", [Pure]> {
+  : QuidditchSnitch_Op<"completed_token", [Pure, ConstantLike]> {
 
   let description = [{
     Op returning a special value representing a completed DMA transfer.
@@ -302,6 +306,8 @@ def QuidditchSnitch_CompletedTokenOp
   let assemblyFormat = [{
     attr-dict
   }];
+
+  let hasFolder = 1;
 }
 
 def QuidditchSnitch_BarrierOp : QuidditchSnitch_Op<"barrier"> {


### PR DESCRIPTION
This is the attribute version corresponding to the `completed_token` operation. The latter is now a `ConstantLike` that folds to this token value.

The main advantage is the more comfortable use of the `fold` API rather than canonicalization patterns.