### PR TITLE
[PromoteToL1] Fix dominance bug

### DIFF
--- a/codegen/tests/Dialect/Snitch/Transforms/promote-operands-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-operands-to-l1.mlir
@@ -1,4 +1,4 @@
-// RUN: quidditch-opt %s -p "builtin.module(func.func(quidditch-promote-operands-to-l1))" | FileCheck %s
+// RUN: quidditch-opt %s -p "builtin.module(func.func(quidditch-promote-operands-to-l1))" --allow-unregistered-dialect | FileCheck %s
 
 // CHECK-LABEL: @test(
 // CHECK-SAME: %[[A:[[:alnum:]]+]]: tensor<32x32xf32>
@@ -14,5 +14,15 @@ func.func @test(%a : tensor<32x32xf32>, %b : tensor<32x32xf32>) -> tensor<32x32x
   // CHECK: %[[E2:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[E]] to %[[E1]] using %[[TOKEN]]
   // CHECK: linalg.matmul ins(%[[A2]], %[[B2]] : {{.*}}) outs(%[[E2]] : {{.*}})
   %r = linalg.matmul ins(%a, %b : tensor<32x32xf32>, tensor<32x32xf32>) outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
+  return %r : tensor<32x32xf32>
+}
+
+// CHECK-LABEL: @test_dominance(
+// CHECK-SAME: %[[A:[[:alnum:]]+]]
+func.func @test_dominance(%a : tensor<32x32xf32>) -> tensor<32x32xf32> {
+  // CHECK: "test.use"(%[[A]])
+  "test.use"(%a) : (tensor<32x32xf32>) -> ()
+  %e = bufferization.alloc_tensor() : tensor<32x32xf32>
+  %r = linalg.abs ins(%a : tensor<32x32xf32>) outs(%e : tensor<32x32xf32>) -> tensor<32x32xf32>
   return %r : tensor<32x32xf32>
 }


### PR DESCRIPTION
The pass would previously create invalid IR by always replacing a tensor value with the promoted tensor despite its insertion point being before a compute operation. If another operation before the compute operation would have a use of the tensor it'd get replaced despite being illegal.

The fix is to simply not replace the value of the tensor but rather the operand use. CSE should clean up any redundancy.