### PR TITLE
[Target] Implement pass inserting `tensor.pad` if required

### DIFF
--- a/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
         "ConfigureForSnitch.cpp"
         "DisableQuidditchVariant.cpp"
         "LinkExecutables.cpp"
+        "PadToTilingConfig.cpp"
         "ReluToMax.cpp"
         "RemoveTrivialLoops.cpp"
         "TensorTile.cpp"

--- a/codegen/compiler/src/Quidditch/Target/PadToTilingConfig.cpp
+++ b/codegen/compiler/src/Quidditch/Target/PadToTilingConfig.cpp
@@ -1,0 +1,436 @@
+#include "Passes.h"
+
+#include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.h"
+#include "iree/compiler/Codegen/Dialect/Codegen/IR/IREECodegenAttrs.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace quidditch {
+#define GEN_PASS_DEF_PADTOTILINGCONFIGPASS
+#include "Quidditch/Target/Passes.h.inc"
+} // namespace quidditch
+
+using namespace mlir;
+using namespace quidditch::Snitch;
+using namespace mlir::iree_compiler;
+
+namespace {
+class PadToTilingConfig
+    : public quidditch::impl::PadToTilingConfigPassBase<PadToTilingConfig> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Returns true if it is legal to zero-pad the given linalg operation.
+/// Legal is defined as being able to extend the iteration space and the
+/// corresponding operands using zero-padding without changing the values
+/// in the slice corresponding to the ops original result.
+static bool canZeroPad(linalg::LinalgOp linalgOp) {
+  // Elementwise operations can be padded with any value as there are no cross
+  // dimension data dependencies.
+  if (linalgOp.getNumParallelLoops() == linalgOp.getNumLoops())
+    return true;
+
+  // Contractions can be zero padded.
+  if (linalg::isaContractionOpInterface(linalgOp))
+    return true;
+
+  // Convolutions can be zero padded.
+  return linalg::isaConvolutionOpInterface(linalgOp);
+}
+
+static LogicalResult padToMultipleOf(linalg::LinalgOp &linalgOp,
+                                     SmallVector<int64_t> config) {
+  for (int64_t &value : config)
+    if (value == 0)
+      value = 1;
+
+  auto options =
+      linalg::LinalgPaddingOptions()
+          .setPaddingDimensions(
+              llvm::to_vector(llvm::seq<int64_t>(config.size())))
+          .setPadToMultipleOf(config)
+          .setCopyBackOp(linalg::LinalgPaddingOptions::CopyBackOp::None);
+
+  auto loweringConfig = getLoweringConfig<LoweringConfigAttr>(linalgOp);
+
+  auto builder = IRRewriter(linalgOp);
+  SmallVector<tensor::PadOp> padOps;
+  linalg::LinalgOp oldOp = linalgOp;
+  SmallVector<Value> replacements;
+  if (failed(linalg::rewriteAsPaddedOp(builder, linalgOp, options, linalgOp,
+                                       replacements, padOps)))
+    return failure();
+  builder.replaceOp(oldOp, replacements);
+
+  if (loweringConfig)
+    setLoweringConfig(linalgOp, loweringConfig);
+  return success();
+}
+
+static LogicalResult padToTileSize(linalg::LinalgOp &linalgOp,
+                                   std::optional<IntegerAttr> computeCores) {
+  SmallVector<int64_t> tileSize;
+  if (auto loweringConfig = getLoweringConfig<LoweringConfigAttr>(linalgOp)) {
+    for (auto getTileSizeMem : {&LoweringConfigAttr::getWorkgroupTiles,
+                                &LoweringConfigAttr::getL1Tiles}) {
+      tileSize = llvm::to_vector((loweringConfig.*getTileSizeMem)());
+      size_t numLoops = linalgOp.getNumLoops();
+      while (tileSize.size() < numLoops)
+        tileSize.push_back(0);
+
+      if (failed(padToMultipleOf(linalgOp, tileSize)))
+        return failure();
+    }
+  }
+
+  if (!computeCores)
+    return success();
+
+  // TODO: This duplicates the logic for thread tiling risking them to go out of
+  //       sync.
+  //       We probably want 'LoweringConfigAttr' to include these tile sizes
+  //       in the future as well.
+  if (tileSize.empty())
+    tileSize = linalgOp.getStaticLoopRanges();
+
+  std::optional<unsigned> largestParallelDim;
+  std::optional<int64_t> largestParallelSize;
+  for (auto [index, iterType, range] :
+       llvm::enumerate(linalgOp.getIteratorTypesArray(), tileSize)) {
+    // Not doing reduction tiling.
+    if (iterType == utils::IteratorType::reduction) {
+      range = 0;
+      continue;
+    }
+
+    // Not tileable.
+    if (range <= 1) {
+      range = 0;
+      continue;
+    }
+
+    // Not tiling dynamic dimensions right now.
+    if (range == ShapedType::kDynamic) {
+      range = 0;
+      continue;
+    }
+
+    if (!largestParallelSize || range > largestParallelSize) {
+      largestParallelDim = index;
+      largestParallelSize = range;
+    }
+  }
+
+  if (largestParallelDim) {
+    assert(largestParallelSize);
+    tileSize[*largestParallelDim] = llvm::divideCeil(
+        *largestParallelSize, computeCores->getValue().getSExtValue());
+  }
+
+  return padToMultipleOf(linalgOp, std::move(tileSize));
+}
+
+/// Returns true if the given pad operation uses an undefined value as padding
+/// value.
+static bool hasUndefPadding(tensor::PadOp padOp) {
+  Value constant = padOp.getConstantPaddingValue();
+  return constant &&
+         matchPattern(constant, m_Constant<ub::PoisonAttrInterface>(nullptr));
+}
+
+/// Clones 'padOp' using 'rewriter' and replaces its padding value with an
+/// undefined value.
+static tensor::PadOp cloneWithUndefPad(PatternRewriter &rewriter,
+                                       tensor::PadOp padOp) {
+  auto newPadOp = cast<tensor::PadOp>(rewriter.cloneWithoutRegions(*padOp));
+  {
+    OpBuilder::InsertionGuard guard{rewriter};
+    rewriter.setInsertionPointToEnd(&newPadOp.getRegion().emplaceBlock());
+    for (unsigned _ : llvm::seq(padOp.getSource().getType().getRank()))
+      newPadOp.getRegion().addArgument(rewriter.getIndexType(),
+                                       padOp->getLoc());
+
+    // TODO: This is very wrong as poison is stronger than undef as there are
+    //       operations where a poison value will cause immediate undefined
+    //       behaviour where an undef value wouldn't.
+    //       Our lowering does the equivalent of using an undef value for now
+    //       but things like folding won't respect it.
+    //       The correct fix would be to have `ub.freeze` upstream.
+    Value poison = rewriter.create<ub::PoisonOp>(
+        newPadOp->getLoc(), padOp.getType().getElementType());
+    rewriter.create<tensor::YieldOp>(padOp->getLoc(), poison);
+  }
+  return newPadOp;
+}
+
+namespace {
+
+// Patterns applied on linalg operations to turn zero pads created by the
+// padding rewriter into undef pads.
+// Note that these assume that padding of results are not consumed in a way
+// where its semantics have any impact on the final output.
+// In simplified words: The linalg's result is only used by the `extract_slice`
+// which extracts the slice corresponding to the original unpadded computation.
+//
+// TODO: This might be cleaner to implement right after or during the padding
+//       rewrite.
+
+/// Optimizes every operand of an elementwise operation to be undef padded.
+struct OptimizeElementwisePad : OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
+                                PatternRewriter &rewriter) const override {
+    // Only elementwise operations.
+    if (linalgOp.getNumLoops() != linalgOp.getNumParallelLoops())
+      return failure();
+
+    bool changed = false;
+    for (OpOperand &operand : linalgOp->getOpOperands()) {
+      auto padOp = operand.get().getDefiningOp<tensor::PadOp>();
+      if (!padOp)
+        continue;
+
+      if (hasUndefPadding(padOp))
+        continue;
+
+      auto newPadOp = cloneWithUndefPad(rewriter, padOp);
+      rewriter.modifyOpInPlace(linalgOp, [&] { operand.set(newPadOp); });
+      changed = true;
+    }
+    return success(changed);
+  }
+};
+
+/// Optimizes the init operand of a contraction operation to be undef padded.
+struct OptimizeContractionOutputPad
+    : OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
+                                PatternRewriter &rewriter) const override {
+    if (!linalg::isaContractionOpInterface(linalgOp))
+      return failure();
+
+    bool changed = false;
+    for (OpOperand &operand : linalgOp.getDpsInitsMutable()) {
+      auto padOp = operand.get().getDefiningOp<tensor::PadOp>();
+      if (!padOp)
+        continue;
+
+      if (hasUndefPadding(padOp))
+        continue;
+
+      auto newPadOp = cloneWithUndefPad(rewriter, padOp);
+      rewriter.modifyOpInPlace(linalgOp, [&] { operand.set(newPadOp); });
+      changed = true;
+    }
+    return success(changed);
+  }
+};
+
+/// Optimizes operands that are padded but only contribute to an output tensor
+/// that is undef padded to also be undef padded.
+struct PropagateUnusedOutputPads : OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
+                                PatternRewriter &rewriter) const override {
+    SmallVector<AffineMap> indexingMaps = linalgOp.getIndexingMapsArray();
+
+    bool changed = false;
+    // For every operand, go through all inits tensors and find which of its
+    // dimensions have been undef padded. The corresponding dimensions of the
+    // operands can then also be undef padded.
+    // If true for every dim of the operand, for every output, the entire
+    // operand can be undef padded.
+    for (auto [operandMap, operand] :
+         llvm::zip_equal(indexingMaps, linalgOp->getOpOperands())) {
+      auto operandPadOp = operand.get().getDefiningOp<tensor::PadOp>();
+      // Already undef padded.
+      if (!operandPadOp || hasUndefPadding(operandPadOp))
+        continue;
+
+      bool canUndefPad = true;
+      for (OpOperand &inits : linalgOp.getDpsInitsMutable()) {
+        auto padOp = inits.get().getDefiningOp<tensor::PadOp>();
+        if (!padOp || !hasUndefPadding(padOp)) {
+          canUndefPad = false;
+          break;
+        }
+
+        // Initially, all padded dims need non-undef padding.
+        llvm::SmallBitVector needNonUndefPadding = operandPadOp.getPaddedDims();
+
+        llvm::SmallBitVector initsPaddedDims = padOp.getPaddedDims();
+        // Create a mapping from the init dims to the operand dims.
+        // The init dims affine map must be invertible for this to be possible.
+        AffineMap initsMap = linalgOp.getMatchingIndexingMap(&inits);
+        AffineMap inverted = inverseAndBroadcastProjectedPermutation(initsMap);
+        if (!inverted) {
+          canUndefPad = false;
+          break;
+        }
+
+        AffineMap initsToOperand = operandMap.compose(inverted);
+        for (unsigned index : initsPaddedDims.set_bits())
+          if (std::optional<unsigned> position =
+                  initsToOperand.getResultPosition(
+                      rewriter.getAffineDimExpr(index)))
+            needNonUndefPadding[*position] = false;
+
+        if (needNonUndefPadding.any()) {
+          canUndefPad = false;
+          break;
+        }
+      }
+      if (!canUndefPad)
+        continue;
+
+      rewriter.modifyOpInPlace(linalgOp, [&, &operand = operand] {
+        operand.set(cloneWithUndefPad(rewriter, operandPadOp));
+      });
+      changed = true;
+    }
+    return success(changed);
+  }
+};
+
+} // namespace
+
+namespace {
+
+/// Expands a 'pad_undef(empty)' to a larger empty.
+struct ExpandPaddedEmptyOp : OpRewritePattern<tensor::PadOp> {
+  using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PadOp padOp,
+                                PatternRewriter &rewriter) const override {
+    if (!hasUndefPadding(padOp))
+      return failure();
+
+    auto emptyOp = padOp.getSource().getDefiningOp<tensor::EmptyOp>();
+    if (!emptyOp)
+      return failure();
+
+    ReifiedRankedShapedTypeDims dims;
+    if (failed(reifyResultShapes(rewriter, padOp, dims)))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<tensor::EmptyOp>(
+        padOp, dims.front(), getElementTypeOrSelf(padOp.getType()));
+    return success();
+  }
+};
+
+/// Expands a 'pad_undef(extract_slice)' to a larger extract_slice if possible.
+struct ExpandPaddedSlice : OpRewritePattern<tensor::PadOp> {
+  using OpRewritePattern<tensor::PadOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::PadOp padOp,
+                                PatternRewriter &rewriter) const override {
+    // Lower padding and dynamic padding values are currently unsupported.
+    if (!hasUndefPadding(padOp) || !padOp.hasZeroLowPad() ||
+        !padOp.getHigh().empty())
+      return failure();
+
+    auto extractSlice =
+        padOp.getSource().getDefiningOp<tensor::ExtractSliceOp>();
+    // Only zero-offset supported right now to simplify the logic.
+    if (!extractSlice || !extractSlice.hasZeroOffset())
+      return failure();
+
+    TypedValue<RankedTensorType> source = extractSlice.getSource();
+    if (extractSlice.getType().getRank() != source.getType().getRank())
+      return failure();
+
+    // Check that the pad does not make the tensor larger than the original
+    // source of the slice.
+    ArrayRef<int64_t> high = padOp.getStaticHigh();
+    for (auto [highPad, sourceShape, resultShape] : llvm::zip_equal(
+             high, source.getType().getShape(), padOp.getType().getShape())) {
+      if (highPad == 0)
+        continue;
+
+      if (sourceShape < resultShape)
+        return failure();
+    }
+
+    ReifiedRankedShapedTypeDims dims;
+    if (failed(reifyResultShapes(rewriter, padOp, dims)))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
+        padOp, source, /*offsets=*/
+        SmallVector<OpFoldResult>(source.getType().getRank(),
+                                  rewriter.getIndexAttr(0)),
+        /*sizes=*/dims.front(),
+        /*strides=*/
+        SmallVector<OpFoldResult>(source.getType().getRank(),
+                                  rewriter.getIndexAttr(1)));
+    return success();
+  }
+};
+} // namespace
+
+void PadToTilingConfig::runOnOperation() {
+  // TODO: This is seems like a horrible restriction and should be fixed.
+  if (getOperation()
+          ->walk([&](tensor::PadOp padOp) {
+            padOp.emitError(
+                "pass does not handle pre-existing padding operations");
+            return WalkResult::interrupt();
+          })
+          .wasInterrupted())
+    return signalPassFailure();
+
+  SmallVector<linalg::LinalgOp> workList;
+  getOperation()->walk([&](linalg::LinalgOp linalgOp) {
+    if (!canZeroPad(linalgOp))
+      return;
+    workList.push_back(linalgOp);
+  });
+
+  std::optional<IntegerAttr> attr = getConfigIntegerAttr(
+      IREE::HAL::ExecutableTargetAttr::lookup(getOperation()), "compute_cores");
+
+  // Pad every linalg op to a multiple of all applied tile sizes.
+  for (linalg::LinalgOp &linalgOp : workList)
+    if (failed(padToTileSize(linalgOp, attr)))
+      return signalPassFailure();
+
+  // First perform just the conversion of zero-pads to undef-pads.
+  // These must run separately from later patterns that may erase pad ops
+  // entirely which discards information required by these patterns.
+  {
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<OptimizeElementwisePad, PropagateUnusedOutputPads,
+                    OptimizeContractionOutputPad>(&getContext());
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+
+  {
+    RewritePatternSet patterns(&getContext());
+    linalg::populateSwapExtractSliceWithFillPatterns(patterns);
+    linalg::FillOp::getCanonicalizationPatterns(patterns, &getContext());
+    getContext()
+        .getLoadedDialect<tensor::TensorDialect>()
+        ->getCanonicalizationPatterns(patterns);
+    tensor::PadOp::getCanonicalizationPatterns(patterns, &getContext());
+    patterns.insert<ExpandPaddedEmptyOp, ExpandPaddedSlice>(&getContext());
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+}

--- a/codegen/compiler/src/Quidditch/Target/Passes.td
+++ b/codegen/compiler/src/Quidditch/Target/Passes.td
@@ -23,6 +23,7 @@ def DisableQuidditchVariantPass : Pass<"quidditch-disable-variant",
 }
 
 def ReluToMaxPass : Pass<"quidditch-relu-to-max">;
+def PadToTilingConfigPass : Pass<"quidditch-pad-to-tiling-config">;
 
 def ConfigureForSnitchPass
   : InterfacePass<"quidditch-configure-for-snitch",

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -175,12 +175,11 @@ public:
     FunctionLikeNest(modulePassManager)
         .addPass([] { return createTileAndDistributeToWorkgroupsPass(); })
         .addPass([] { return createConvertToDestinationPassingStylePass(); })
+        .addPass(quidditch::createPadToTilingConfigPass)
         .addPass(createFoldAffineMinInDistributedLoopsPass)
         .addPass(quidditch::createRemoveTrivialLoopsPass)
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass)
-        .addPass(createFuseTensorPadWithConsumerPass)
-        .addPass(createConcretizePadResultShapePass)
         .addPass([] {
           return quidditch::createTensorTilePass(
               {quidditch::TilingLevel::Reduction});
@@ -190,7 +189,11 @@ public:
         .addPass([] {
           return quidditch::createTensorTilePass({quidditch::TilingLevel::L1});
         })
+        .addPass(createFuseTensorPadWithConsumerPass)
+        .addPass(createConcretizePadResultShapePass)
         .addPass(quidditch::Snitch::createPromoteOperandsToL1Pass)
+        .addPass(createCanonicalizerPass)
+        .addPass(createCSEPass)
         .addPass(quidditch::Snitch::createPipelineCopyComputePass)
         // TODO: Fuse scf.forall after.
         .addPass([] {

--- a/codegen/tests/Target/pad-to-tiling-config.mlir
+++ b/codegen/tests/Target/pad-to-tiling-config.mlir
@@ -1,0 +1,45 @@
+// RUN: quidditch-opt %s -p "builtin.module(func.func(quidditch-pad-to-tiling-config))" | FileCheck %s
+
+// CHECK-LABEL: @test(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+func.func @test(%arg0 : tensor<33xf32>) -> tensor<33xf32> attributes {
+  hal.executable.target = #hal.executable.target<"", "", {compute_cores = 8 : i32}>
+} {
+  // CHECK: %[[POISON:.*]] = ub.poison
+  // CHECK: %[[PAD:.*]] = tensor.pad %[[ARG0]]
+  // CHECK-SAME: low[0]
+  // CHECK-SAME: high[2]
+  // CHECK: tensor.yield %[[POISON]]
+  // CHECK: %[[EMPTY:.*]] = tensor.empty
+  %1 = tensor.empty() : tensor<33xf32>
+  // CHECK: %[[ABS:.*]] = linalg.abs ins(%[[PAD]] :
+  // CHECK-SAME: outs(%[[EMPTY]] :
+  %0 = linalg.abs ins(%arg0 : tensor<33xf32>) outs(%1 : tensor<33xf32>) -> tensor<33xf32>
+  // CHECK: %[[SLICE:.*]] = tensor.extract_slice %[[ABS]][0] [33]
+  // CHECK: return %[[SLICE]]
+  return %0 : tensor<33xf32>
+}
+
+// CHECK-LABEL: @test_contraction_activation(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+func.func @test_contraction_activation(%arg0 : tensor<1x33xf32>, %arg1 : tensor<11x33xf32>) -> tensor<1x11xf32> attributes {
+  hal.executable.target = #hal.executable.target<"", "", {compute_cores = 8 : i32}>
+} {
+  // CHECK: %[[POISON:.*]] = ub.poison
+  // CHECK: %[[EMPTY:.*]] = tensor.empty
+  // CHECK: %[[PAD:.*]] = tensor.pad %[[ARG1]]
+  // CHECK-SAME: low[0, 0]
+  // CHECK-SAME: high[1, 0]
+  // CHECK: tensor.yield %[[POISON]]
+  %1 = tensor.empty() : tensor<1x11xf32>
+  // CHECK: %[[MATMUL:.*]] = linalg.matmul_transpose_b ins(%[[ARG0]], %[[PAD]] :
+  // CHECK-SAME: outs(%[[EMPTY]] :
+  %0 = linalg.matmul_transpose_b ins(%arg0, %arg1 : tensor<1x33xf32>, tensor<11x33xf32>) outs(%1 : tensor<1x11xf32>) -> tensor<1x11xf32>
+  // CHECK: %[[ABS:.*]] = linalg.abs ins(%[[MATMUL]] :
+  // CHECK-SAME: outs(%[[MATMUL]] :
+  %2 = linalg.abs ins(%0 : tensor<1x11xf32>) outs(%0 : tensor<1x11xf32>) -> tensor<1x11xf32>
+  // CHECK: %[[SLICE:.*]] = tensor.extract_slice %[[ABS]][0, 0] [1, 11]
+  // CHECK: return %[[SLICE]]
+  return %2 : tensor<1x11xf32>
+}


### PR DESCRIPTION
In the future we will have scenarios requiring padding to be inserted to be able to effectively tile and vectorize operations.

This pass implements the logic required to insert and optimize `tensor.pad` operations to pad operands of linalg operations to a multiple of a given number. The current logic only does so for tile sizes.

Optimization wise, the pass optimizes zero-padding to undef-padding where possible and attempts to fuse them into various operations when possible.

A future pass will lower `tensor.pad` to DMA transfers to fully integrate it into compilation flow.