### PR TITLE
[quidditch_snitch] Implement undef padding for `start_tensor_copy`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.cpp
@@ -636,7 +636,7 @@ StartTensorCopyOp::bufferize(RewriterBase &rewriter,
   // Zero out the entire buffer prior to overwriting it with the copied values.
   // TODO: This could be optimized to only zero regions that won't be filled
   //  with the copied values at the cost of 2^rank transfers instead of two.
-  if (hasPadding())
+  if (hasPadding() && !getUndefPadding())
     rewriter.create<StartZeroMemTransferOp>(getLoc(), *alloc);
 
   // Subview into the original memory without any padding.

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.td
@@ -199,7 +199,8 @@ def QuidditchSnitch_StartTensorCopyOp : QuidditchSnitch_Op<"start_tensor_copy",
 
   let arguments = (ins AnyRankedTensor:$copy,
                        Variadic<Index>:$high_pad,
-                       OptionalAttr<DenseI64ArrayAttr>:$static_high_pad
+                       OptionalAttr<DenseI64ArrayAttr>:$static_high_pad,
+                       UnitAttr:$undef_padding
   );
 
   let results = (outs
@@ -209,7 +210,7 @@ def QuidditchSnitch_StartTensorCopyOp : QuidditchSnitch_Op<"start_tensor_copy",
 
   let assemblyFormat = [{
     $copy `to` `L1`
-    ( `pad` `with` `zero` `to`
+    ( `pad` `with` (`undef` $undef_padding^) : (`zero`)? `to`
       custom<DynamicIndexList>($high_pad, $static_high_pad)^)?
     `:` type($copy) `->` type($result) attr-dict
   }];

--- a/codegen/tests/Dialect/Snitch/Transforms/promote-pads-to-l1.mlir
+++ b/codegen/tests/Dialect/Snitch/Transforms/promote-pads-to-l1.mlir
@@ -22,7 +22,7 @@ func.func @test_zero_f32(%a : tensor<32x32xf32>) -> tensor<33x33xf32> {
 func.func @test_poison(%a : tensor<32x32xf32>) -> tensor<33x33xf32> {
   %c = ub.poison : f32
   // CHECK: %[[R:.*]], %[[T:.*]] = quidditch_snitch.start_tensor_copy %[[A]]
-  // CHECK-SAME: pad with zero to [1, 1]
+  // CHECK-SAME: pad with undef to [1, 1]
   // CHECK: %[[R2:.*]] = quidditch_snitch.wait_for_tensor_copy of %[[A]]
   // CHECK-SAME: to %[[R]]
   // CHECK-SAME: using %[[T]]


### PR DESCRIPTION
Undef padding was previously lowered to zero paddings, which involve additional DMA transfers required to zero out an allocation. The majority of operations do not require padding with a specific value making the zero padding and therefore the DMA transfers redundant.