### PR TITLE
[quidditch_snitch] Remove redundant `start_tensor_copy` op in more cases

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.cpp
@@ -456,8 +456,10 @@ LogicalResult StartTensorCopyOp::fold(FoldAdaptor adaptor,
   auto copyOp = waitOp.getTransferTensor().getDefiningOp<StartTensorCopyOp>();
   if (!copyOp)
     return failure();
-  if (copyOp.getStaticHighPadAttr() != getStaticHighPadAttr() ||
-      copyOp.getHighPad() != getHighPad())
+
+  if (hasPadding() &&
+      (copyOp.getStaticHighPadAttr() != getStaticHighPadAttr() ||
+       copyOp.getHighPad() != getHighPad()))
     return failure();
 
   results.emplace_back(waitOp);


### PR DESCRIPTION
The folder logic was too conservative and would not elide a tensor copy if the tensor it was transferring was padded. The intended logic was to not elide the copy if the copy itself is padded unless the padding matches the tensor being transferred.