### PR TITLE
[ConvertSnitchToLLVM] Improve DMA transfers contiguity check

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -145,24 +145,7 @@ struct StartDMATransferOp1DLowering
                                               });
   }
 };
-} // namespace
 
-static StridedLayoutAttr identityStride(MemRefType type) {
-  SmallVector<int64_t> strides{1};
-  for (int64_t dim : llvm::reverse(type.getShape().drop_back())) {
-    if (ShapedType::isDynamic(dim))
-      break;
-    strides.push_back(strides.back() * dim);
-  }
-
-  while (strides.size() < type.getShape().size())
-    strides.push_back(ShapedType::kDynamic);
-
-  std::reverse(strides.begin(), strides.end());
-  return StridedLayoutAttr::get(type.getContext(), 0, strides);
-}
-
-namespace {
 struct StartDMATransferOp2DLowering
     : ConvertOpToLLVMPattern<StartDMATransferOp> {
 

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer.mlir
@@ -56,9 +56,9 @@ func.func private @test4(%arg0 : memref<1x4xf32>, %arg1 : memref<1x4xf32, stride
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_SIZE:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_STRIDE_N:[[:alnum:]]+]]
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
@@ -67,11 +67,13 @@ func.func private @test4(%arg0 : memref<1x4xf32>, %arg1 : memref<1x4xf32, stride
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
 func.func private @test5(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>) -> !quidditch_snitch.dma_token {
-  // CHECK: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[ELEMENT_WIDTH]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
+  // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK-DAG: %[[FOUR_INDEX:.*]] = llvm.mlir.constant(4 : index)
+  // CHECK-DAG: %[[TWO:.*]] = llvm.mlir.constant(2 : index)
+  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
   // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[ARG0_SIZE]])
+  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[TWO]])
   %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>
   return %0 : !quidditch_snitch.dma_token
 }
@@ -80,14 +82,14 @@ func.func private @test5(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, stride
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_SIZE:[[:alnum:]]+]]
-// CHECK-SAME: %[[DIM1:[[:alnum:]]+]]
+// CHECK-SAME:  %{{[[:alnum:]]+}}
+// CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG0_STRIDE0:[[:alnum:]]+]]
 // CHECK-SAME: %[[ARG0_STRIDE_N:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_ALIGNED_PTR:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
@@ -98,27 +100,30 @@ func.func private @test6(%arg0 : memref<3x2x4xf32>, %arg1 : memref<3x2x4xf32, st
   // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
   // CHECK-DAG: %[[ZERO32:.*]] = llvm.mlir.constant(0 : i32) : i32
   // CHECK-DAG: %[[ZERO:.*]] = llvm.mlir.constant(0 : index) : i32
+  // CHECK-DAG: %[[EIGHT:.*]] = llvm.mlir.constant(8 : {{.*}}) : i32
+  // CHECK-DAG: %[[SIXTEEN:.*]] = llvm.mlir.constant(16 : {{.*}}) : i32
   // CHECK-DAG: %[[ONE:.*]] = llvm.mlir.constant(1 : {{.*}}) : i32
-  // CHECK: %[[ARG1_PTR:.*]] = llvm.getelementptr %[[ARG1_ALIGNED_PTR]][2]
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[ELEMENT_WIDTH]], %[[ELEMENT_WIDTH]]
+  // CHECK-DAG: %[[TWO:.*]] = llvm.mlir.constant(2 : {{.*}}) : i32
+  // CHECK-DAG: %[[THREE:.*]] = llvm.mlir.constant(3 : {{.*}}) : i32
+  // CHECK-DAG: %[[FOUR_INDEX:.*]] = llvm.mlir.constant(4 : index)
+
+  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
   // CHECK: llvm.br ^[[BB1:.*]](%[[ZERO]], %[[ZERO32]]
 
   // CHECK: ^[[BB1]](%[[IV1:.*]]: i32, %[[IV2:.*]]: i32):
-  // CHECK: %[[COND:.*]] = llvm.icmp "slt" %[[IV1]], %[[ARG0_SIZE]]
+  // CHECK: %[[COND:.*]] = llvm.icmp "slt" %[[IV1]], %[[THREE]]
   // CHECK: llvm.cond_br %[[COND]], ^[[BODY:.*]], ^[[EXIT:[[:alnum:]]+]]
 
   // CHECK: ^[[BODY]]:
-  // CHECK: %[[MUL:.*]] = llvm.mul %[[IV1]], %[[ARG0_STRIDE0]]
-  // CHECK: %[[ARG0_OFFSET1:.*]] = llvm.add %[[MUL]], %[[ZERO32]]
-  // CHECK: %[[ARG0_ADJUSTED:.*]] = llvm.getelementptr %[[ARG0_PTR]][%[[ARG0_OFFSET1]]]
+  // CHECK: %[[MUL1:.*]] = llvm.mul %[[IV1]], %[[EIGHT]]
+  // CHECK: %[[MUL2:.*]] = llvm.mul %[[IV1]], %[[SIXTEEN]]
+  // CHECK: %[[ARG0_OFFSET1:.*]] = llvm.add %[[MUL2]], %[[TWO]]
+  // CHECK: %[[ARG0_ADJUSTED:.*]] = llvm.getelementptr %[[ARG0_PTR]][%[[MUL1]]]
+  // CHECK: %[[ARG1_ADJUSTED:.*]] = llvm.getelementptr %[[ARG1_PTR]][%[[ARG0_OFFSET1]]]
 
-  // CHECK: %[[MUL:.*]] = llvm.mul %[[IV1]], %[[ARG1_STRIDE0]]
-  // CHECK: %[[ARG1_OFFSET1:.*]] = llvm.add %[[MUL]], %[[ZERO32]]
-  // CHECK: %[[ARG1_ADJUSTED:.*]] = llvm.getelementptr %[[ARG1_PTR]][%[[ARG1_OFFSET1]]]
-
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[RES:.*]] = llvm.call @snrt_dma_start_2d(%[[ARG1_ADJUSTED]], %[[ARG0_ADJUSTED]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[DIM1]])
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[EIGHT]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[RES:.*]] = llvm.call @snrt_dma_start_2d(%[[ARG1_ADJUSTED]], %[[ARG0_ADJUSTED]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[TWO]])
   // CHECK: %[[INV:.*]] = llvm.add %[[IV1]], %[[ONE]]
   // CHECK: llvm.br ^[[BB1]](%[[INV]], %[[RES]]
 
@@ -142,12 +147,38 @@ func.func private @test6(%arg0 : memref<3x2x4xf32>, %arg1 : memref<3x2x4xf32, st
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
-func.func private @dynamic_strides(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[?, 1], offset: 0>>) -> !quidditch_snitch.dma_token {
+func.func private @dynamic_strides(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[?, 1]>>) -> !quidditch_snitch.dma_token {
+  // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
+  // CHECK-DAG: %[[FOUR:.*]] = llvm.mlir.constant(4 : index)
+  // CHECK-DAG: %[[TWO:.*]] = llvm.mlir.constant(2 : index)
+  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[FOUR]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[FOUR]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
+  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[TWO]])
+  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[?, 1]>>
+  return %0 : !quidditch_snitch.dma_token
+}
+
+// CHECK-LABEL: @contigious_dynamic_inner
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG0_SIZE:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG0_STRIDE_0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG0_STRIDE_N:[[:alnum:]]+]]
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
+func.func private @contigious_dynamic_inner(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32, strided<[?, 1]>>) -> !quidditch_snitch.dma_token {
   // CHECK: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[ELEMENT_WIDTH]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[ARG0_STRIDE_0]], %[[ELEMENT_WIDTH]]
   // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
   // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
   // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[ARG0_SIZE]])
-  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[?, 1], offset: 0>>
+  %0 = quidditch_snitch.start_dma_transfer from %arg0 : memref<?x?xf32> to %arg1 : memref<?x?xf32, strided<[?, 1]>>
   return %0 : !quidditch_snitch.dma_token
 }


### PR DESCRIPTION
The previous logic was too overly complicated and had false negatives. Previous PRs that implemented zero-mem transfer added nice helpers that are now used to detect the common contiguous dimensions between a source and destination MemRef.