### PR TITLE
[ConvertSnitchToLLVM] Fix bug in 1d size calculation

### DIFF
--- a/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
+++ b/codegen/compiler/src/Quidditch/Conversion/ConvertSnitchToLLVM.cpp
@@ -121,10 +121,10 @@ struct StartDMATransferOp1DLowering
 
     MemRefType sourceMemRef = op.getSource().getType();
     SmallVector<Value> dynamicSizes;
-    for (std::int64_t dim : sourceMemRef.getShape())
+    for (auto [index, dim] : llvm::enumerate(sourceMemRef.getShape()))
       if (ShapedType::isDynamic(dim))
         dynamicSizes.push_back(
-            sourceDescriptor.size(rewriter, op->getLoc(), dim));
+            sourceDescriptor.size(rewriter, op->getLoc(), index));
 
     SmallVector<Value> sizes;
     SmallVector<Value> strides;

--- a/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer.mlir
+++ b/codegen/tests/Conversion/ConvertSnitchToLLVM/dma_transfer.mlir
@@ -45,6 +45,26 @@ func.func private @test3(%arg0 : memref<?x4xf32>, %arg1 : memref<?x4xf32, stride
   return %0 : !quidditch_snitch.dma_token
 }
 
+// CHECK-LABEL: @dynamic_inner(
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG0_DIM1:[[:alnum:]]+]]
+func.func private @dynamic_inner(%subview_3 : memref<1x?xf64, strided<[161, 1], offset: ?>>, %subview_5 : memref<1x?xf64, strided<[81, 1]>>) {
+  // CHECK-DAG: %[[NULL:.*]] = llvm.mlir.zero
+  // CHECK-DAG: %[[ONE:.*]] = llvm.mlir.constant(1 :
+  // CHECK: %[[SIZE:.*]] = llvm.mul %[[ARG0_DIM1]], %[[ONE]]
+  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[NULL]][%[[SIZE]]]
+  // CHECK: %[[BYTES:.*]] = llvm.ptrtoint %[[GEP]]
+  // CHECK: call @snrt_dma_start_1d(
+  // CHECK-SAME: %{{[[:alnum:]]+}}
+  // CHECK-SAME: %{{[[:alnum:]]+}}
+  // CHECK-SAME: %[[BYTES]]
+  %12 = quidditch_snitch.start_dma_transfer from %subview_3 : memref<1x?xf64, strided<[161, 1], offset: ?>> to %subview_5 : memref<1x?xf64, strided<[81, 1]>>
+  return
+}
+
 // CHECK-LABEL: @test4
 func.func private @test4(%arg0 : memref<1x4xf32>, %arg1 : memref<1x4xf32, strided<[40, 1], offset: ?>>) -> !quidditch_snitch.dma_token {
   // CHECK: llvm.call @snrt_dma_start_1d(


### PR DESCRIPTION
Dynamic memrefs were miscompiled as the wrong index was used to read the size of a dynamic dimension.