### PR TITLE
[TensorTile] Merge reduction tiling into L1 tiling

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchAttrs.td
@@ -48,6 +48,7 @@ def TileSizeList : OptionalArrayRefParameter<"int64_t"> {
     $_printer << "[" << $_self << "]"
   }];
 }
+defvar TileInterchangeList = TileSizeList;
 
 def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
   [DeclareAttrInterfaceMethods<IREECodegen_LoweringConfigAttrInterface, [
@@ -63,6 +64,7 @@ def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
   let parameters = (ins
     TileSizeList:$workgroup_tiles,
     TileSizeList:$l1_tiles,
+    TileInterchangeList:$l1_tiles_interchange,
     DefaultValuedParameter<"bool", "false">:$dual_buffer
   );
 
@@ -70,6 +72,7 @@ def QuidditchSnitch_LoweringConfigAttr : QuidditchSnitch_Attr<"LoweringConfig",
     AttrBuilder<(ins
       CArg<"llvm::ArrayRef<int64_t>", "{}">:$workgroupTiles,
       CArg<"llvm::ArrayRef<int64_t>", "{}">:$l1Tiles,
+      CArg<"llvm::ArrayRef<int64_t>", "{}">:$l1TilesInterchange,
       CArg<"bool", "false">:$dualBuffer
     )>
   ];

--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.cpp
@@ -32,9 +32,14 @@ static ArrayRef<int64_t> dropTrailingZeros(ArrayRef<int64_t> array) {
 LoweringConfigAttr LoweringConfigAttr::get(MLIRContext *context,
                                            ArrayRef<int64_t> workgroupTiles,
                                            ArrayRef<int64_t> l1Tiles,
+                                           ArrayRef<int64_t> l1TilesInterchange,
                                            bool dualBuffer) {
-  return Base::get(context, dropTrailingZeros(workgroupTiles),
-                   dropTrailingZeros(l1Tiles), dualBuffer);
+  l1Tiles = dropTrailingZeros(l1Tiles);
+  auto interchange = llvm::to_vector(l1TilesInterchange);
+  llvm::erase_if(interchange,
+                 [&](int64_t value) { return value >= l1Tiles.size(); });
+  return Base::get(context, dropTrailingZeros(workgroupTiles), l1Tiles,
+                   interchange, dualBuffer);
 }
 
 //===----------------------------------------------------------------------===//

--- a/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
+++ b/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
@@ -57,51 +57,44 @@ static LogicalResult setRootConfig(FunctionOpInterface funcOp,
         //   only applicable once on Occamy.
         SmallVector<int64_t> workgroupTiles(3, 0);
         SmallVector<int64_t> l1Tiles(3, 0);
-        bool dualBuffer = false;
+        SmallVector<int64_t> l1Interchange = {2, 0, 1};
+        bool dualBuffer = true;
 
         if (funcOp.getName() ==
             "main$async_dispatch_9_matmul_transpose_b_1x161x600_f64") {
-          workgroupTiles[2] = 100;
-
           l1Tiles[0] = 0;
           l1Tiles[1] = 56;
-          dualBuffer = true;
+          l1Tiles[2] = 100;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_0_matmul_transpose_b_1x400x161_f64") {
           l1Tiles[1] = 40;
+          // TODO: Switch to 82 and true once correctness bugs are fixed.
           l1Tiles[2] = 0;
+          dualBuffer = false;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_7_matmul_transpose_b_1x600x400_f64") {
-          workgroupTiles[2] = 100;
-
           l1Tiles[0] = 0;
           l1Tiles[1] = 40;
-          l1Tiles[2] = 0;
-          dualBuffer = true;
+          l1Tiles[2] = 100;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_8_matmul_transpose_b_1x600x600_f64") {
-          workgroupTiles[2] = 100;
-
           l1Tiles[0] = 0;
           l1Tiles[1] = 40;
-          dualBuffer = true;
+          l1Tiles[2] = 100;
         }
         if (funcOp.getName() ==
             "main$async_dispatch_1_matmul_transpose_b_1x1200x400_f64") {
-          workgroupTiles[2] = 100;
-
           l1Tiles[0] = 0;
           l1Tiles[1] = 40;
-          l1Tiles[2] = 0;
-          dualBuffer = true;
+          l1Tiles[2] = 100;
         }
 
         setLoweringConfig(rootOp, quidditch::Snitch::LoweringConfigAttr::get(
                                       rootOp->getContext(), workgroupTiles,
-                                      l1Tiles, dualBuffer));
+                                      l1Tiles, l1Interchange, dualBuffer));
         return success();
       })
       .Default(success());

--- a/codegen/compiler/src/Quidditch/Target/Passes.h
+++ b/codegen/compiler/src/Quidditch/Target/Passes.h
@@ -7,9 +7,6 @@
 namespace quidditch {
 
 enum class TilingLevel {
-  /// Applies any reduction tiling that was specified in the workgroup tile
-  /// sizes list but could not be be performed by workgroup tiling.
-  Reduction,
   /// Performs tiling within a workgroup to fit all tensors required for the
   /// root operation into L1.
   L1,

--- a/codegen/compiler/src/Quidditch/Target/Passes.td
+++ b/codegen/compiler/src/Quidditch/Target/Passes.td
@@ -33,11 +33,11 @@ def TensorTilePass : InterfacePass<"quidditch-tensor-tile",
   "mlir::FunctionOpInterface"> {
   let options = [
     Option<"tilingLevel", "tiling-level", "quidditch::TilingLevel",
-           /*default=*/"quidditch::TilingLevel::Reduction",
+           /*default=*/"quidditch::TilingLevel::L1",
            "Tiling level to tile. Supported levels are 'reduction' and 'thread'",
            [{llvm::cl::values(
-              clEnumValN(quidditch::TilingLevel::Reduction, "reduction",
-                         "Tile and fuse all annotated ops to serial loops"),
+              clEnumValN(quidditch::TilingLevel::L1, "l1",
+                         "Tile and fuse all annotated ops to fit into L1 memory"),
               clEnumValN(quidditch::TilingLevel::Thread, "thread",
                          "Tile and fuse all annotated ops to threads")
            )}]>,

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -183,12 +183,6 @@ public:
         .addPass(createFuseTensorPadWithConsumerPass)
         .addPass(createConcretizePadResultShapePass)
         .addPass([] {
-          return quidditch::createTensorTilePass(
-              {quidditch::TilingLevel::Reduction});
-        })
-        .addPass(createCanonicalizerPass)
-        .addPass(createCSEPass)
-        .addPass([] {
           return quidditch::createTensorTilePass({quidditch::TilingLevel::L1});
         })
         .addPass(createFuseTensorPadWithConsumerPass)
@@ -197,6 +191,7 @@ public:
         .addPass(quidditch::Snitch::createPromoteOperandsToL1Pass)
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass)
+        .addPass(createLoopInvariantCodeMotionPass)
         .addPass(quidditch::Snitch::createPipelineCopyComputePass)
         // TODO: Fuse scf.forall after.
         .addPass([] {
@@ -205,7 +200,6 @@ public:
         })
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass)
-        .addPass(createLoopInvariantCodeMotionPass)
         .addPass(quidditch::Snitch::createFormMicrokernelsPass);
 
     BufferizationOptions::AllocationFn allocationFn =


### PR DESCRIPTION
Conceptually, reduction tiling achieves the same goal as L1 tiling: Both ensure that the output tile is in L1 memory. The main reason why this used to be an extra step nevertheless is the performance requirement of tiling reduction prior to any of the parallel dimensions in a matvec to reduce memory transfers. By adding a loop interchange configuration (which could in practice also be hard-coded probably), we can replicate this behavior using only a single tiling config.