### PR TITLE
[SnitchDMA] Split transfer legalization out of `DMAToLLVM`

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/CMakeLists.txt
@@ -1,0 +1,26 @@
+iree_tablegen_library(
+        NAME
+        PassesIncGen
+        TD_FILE
+        "Passes.td"
+        OUTS
+        -name=Transforms --gen-pass-decls Passes.h.inc
+)
+
+iree_cc_library(
+        NAME
+        Passes
+        HDRS
+        "Passes.h"
+        "Passes.h.inc"
+        SRCS
+        "LegalizeDMAOperations.cpp"
+        DEPS
+        ::PassesIncGen
+        Quidditch::Dialect::DMA::IR::DMADialect
+        Quidditch::Dialect::Snitch::IR::QuidditchSnitchDialect
+        MLIRIR
+        MLIRAffineDialect
+        MLIRArithDialect
+        MLIRSCFDialect
+)

--- a/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/LegalizeDMAOperations.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/LegalizeDMAOperations.cpp
@@ -1,0 +1,293 @@
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "Quidditch/Dialect/DMA/IR/DMADialect.h"
+#include "Quidditch/Dialect/DMA/IR/DMAOps.h"
+
+namespace quidditch::SnitchDMA {
+#define GEN_PASS_DEF_LEGALIZEDMAOPERATIONSPASS
+#include "Quidditch/Dialect/SnitchDMA/Transforms/Passes.h.inc"
+} // namespace quidditch::SnitchDMA
+
+namespace {
+class LegalizeDMAOperations
+    : public quidditch::SnitchDMA::impl::LegalizeDMAOperationsPassBase<
+          LegalizeDMAOperations> {
+public:
+  using Base::Base;
+
+protected:
+  void runOnOperation() override;
+};
+} // namespace
+
+using namespace mlir;
+using namespace quidditch::dma;
+
+/// Returns the number of potentially non-contiguous outer dimensions of
+/// 'memRefType'. The remaining inner dimensions (i.e. all dimensions at index
+/// 'NonContiguousOuterDims' to the MemRef rank) are known to be contiguous.
+/// Returns failure if the layout attribute of the MemRef is unsupported.
+static FailureOr<size_t> getNumNonContiguousOuterDims(MemRefType memRefType) {
+  auto stridesAttr =
+      dyn_cast_or_null<StridedLayoutAttr>(memRefType.getLayout());
+  if (!stridesAttr) {
+    if (memRefType.getLayout() && !memRefType.getLayout().isIdentity())
+      return failure();
+
+    // No layout or identity layouts are by definition fully contiguous.
+    return 0;
+  }
+
+  int64_t innerSize = 1;
+  ArrayRef<int64_t> shape = memRefType.getShape();
+  ArrayRef<int64_t> strides = stridesAttr.getStrides();
+  for (; !shape.empty();
+       shape = shape.drop_back(), strides = strides.drop_back()) {
+    int64_t dim = shape.back();
+    // Unit dims can be dropped alongside the corresponding stride of that dim.
+    if (dim == 1)
+      continue;
+
+    int64_t stride = strides.back();
+    if (ShapedType::isDynamic(stride))
+      break;
+
+    if (innerSize != stride)
+      break;
+
+    // Note: Dim may be dynamic with the value -1. This intentionally will only
+    // fail the 'if' above later if the outer dims are non-zero.
+    innerSize *= dim;
+  }
+
+  return shape.size();
+}
+
+/// Returns true if this MemRef type is known to have a fully contiguous layout.
+/// TODO: Could be upstreamed next to
+/// 'memref::isStaticShapeAndContiguousRowMajor'
+static bool isContiguous(MemRefType memRefType) {
+  return getNumNonContiguousOuterDims(memRefType) == 0;
+}
+
+/// Returns true if the given transfer can naively be lowered to Snitch's DMA.
+/// Snitch's DMA may be either one or two dimensional where only the innermost
+/// dimension is contiguous. The outermost may have arbitrary strides.
+static bool isLegal(StartTransferOp transferOp) {
+  MemRefType memRef = transferOp.getSource().getType();
+  // Only 1 or 2D.
+  if (memRef.getRank() > 2)
+    return false;
+
+  FailureOr<size_t> sourceNonCont = getNumNonContiguousOuterDims(memRef);
+  FailureOr<size_t> destNonCont =
+      getNumNonContiguousOuterDims(transferOp.getDest().getType());
+  if (failed(sourceNonCont) || failed(destNonCont))
+    return false;
+
+  return std::max(*sourceNonCont, *destNonCont) == memRef.getRank() - 1;
+}
+
+/// Removes outer unit dimensions from the result type of the subview.
+static void rankReduce(memref::SubViewOp op) {
+  MemRefType resultType = op.getResult().getType();
+  ArrayRef<int64_t> shape = resultType.getShape();
+  shape = shape.drop_while([](int64_t value) { return value == 1; });
+  MemRefLayoutAttrInterface layout;
+  if (auto strided =
+          dyn_cast_or_null<StridedLayoutAttr>(resultType.getLayout()))
+    layout =
+        StridedLayoutAttr::get(op.getContext(), strided.getOffset(),
+                               strided.getStrides().take_back(shape.size()));
+
+  op.getResult().setType(MemRefType::get(shape, resultType.getElementType(),
+                                         layout, resultType.getMemorySpace()));
+};
+
+namespace {
+/// Remove outer unit dimensions.
+struct RankReduceStartTransferOp : OpRewritePattern<StartTransferOp> {
+
+  using OpRewritePattern<StartTransferOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(StartTransferOp op,
+                                PatternRewriter &rewriter) const override {
+    MemRefType type = op.getSource().getType();
+    if (type.getShape().size() <= 1 || type.getShape().front() != 1)
+      return failure();
+
+    SmallVector<OpFoldResult> sizes =
+        memref::getMixedSizes(rewriter, op->getLoc(), op.getSource());
+    SmallVector<OpFoldResult> offsets(sizes.size(), rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> strides(sizes.size(), rewriter.getIndexAttr(1));
+    auto source = rewriter.create<memref::SubViewOp>(
+        op->getLoc(), op.getSource(), offsets, sizes, strides);
+    rankReduce(source);
+    auto dest = rewriter.create<memref::SubViewOp>(op->getLoc(), op.getDest(),
+                                                   offsets, sizes, strides);
+    rankReduce(dest);
+    rewriter.replaceOpWithNewOp<StartTransferOp>(op, source, dest);
+    return success();
+  }
+};
+
+/// Collapse inner contiguous inner dimensions and remove all but possibly one
+/// outer dimension by tiling with size 1 and performing rank-reduction.
+struct CollapseStartTransferOp : OpRewritePattern<StartTransferOp> {
+
+  using OpRewritePattern<StartTransferOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(StartTransferOp op,
+                                PatternRewriter &rewriter) const override {
+    // Must be handled by the rank reduce pattern.
+    if (op.getSource().getType().getShape().front() == 1)
+      return failure();
+
+    FailureOr<size_t> sourceNonContiguous =
+        getNumNonContiguousOuterDims(op.getSource().getType());
+    FailureOr<size_t> destNonContiguous =
+        getNumNonContiguousOuterDims(op.getDest().getType());
+    if (failed(sourceNonContiguous) || failed(destNonContiguous))
+      return failure();
+
+    size_t sharedNonContiguous =
+        std::max(*sourceNonContiguous, *destNonContiguous);
+    // A missing contiguous dimension is handled by the expansion pattern.
+    if (sharedNonContiguous == op.getSource().getType().getRank())
+      return failure();
+
+    TypedValue<MemRefType> source = op.getSource();
+    TypedValue<MemRefType> dest = op.getDest();
+    // Collapse multiple contiguous inner dims into one.
+    if (sharedNonContiguous + 1 < source.getType().getRank()) {
+      SmallVector<ReassociationIndices> reAssociation(sharedNonContiguous + 1);
+      for (unsigned index : llvm::seq(sharedNonContiguous))
+        reAssociation[index].push_back(index);
+
+      llvm::append_range(
+          reAssociation.back(),
+          llvm::seq<int64_t>(sharedNonContiguous, source.getType().getRank()));
+
+      source = rewriter.create<memref::CollapseShapeOp>(op->getLoc(), source,
+                                                        reAssociation);
+      dest = rewriter.create<memref::CollapseShapeOp>(op->getLoc(), dest,
+                                                      reAssociation);
+    }
+
+    // No, or one outer dim is already legal.
+    if (sharedNonContiguous <= 1) {
+      rewriter.replaceOpWithNewOp<StartTransferOp>(op, source, dest);
+      return success();
+    }
+
+    SmallVector<OpFoldResult> sizes =
+        memref::getMixedSizes(rewriter, op->getLoc(), source);
+
+    // Build a loop nest iterating over all outer dimensions - 1.
+    SmallVector<Value> lowerBounds;
+    SmallVector<Value> upperBounds;
+    SmallVector<Value> steps;
+    Value zeroIndex = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 0);
+    Value oneIndex = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1);
+    for (size_t index : llvm::seq(sharedNonContiguous - 1)) {
+      lowerBounds.push_back(zeroIndex);
+      steps.push_back(oneIndex);
+      upperBounds.push_back(getValueOrCreateConstantIndexOp(
+          rewriter, op->getLoc(), sizes[index]));
+    }
+
+    Value completedToken = rewriter.create<CompletedTokenOp>(op->getLoc());
+    scf::LoopNest loopNest = scf::buildLoopNest(
+        rewriter, op->getLoc(), lowerBounds, upperBounds, steps, completedToken,
+        [&](OpBuilder &builder, Location loc, ValueRange ivs,
+            ValueRange iterArgs) -> scf::ValueVector {
+          SmallVector<OpFoldResult> offsets = ivs;
+          SmallVector<OpFoldResult> subSizes(sharedNonContiguous - 1,
+                                             rewriter.getIndexAttr(1));
+          for (auto index : llvm::seq<unsigned>(sharedNonContiguous - 1,
+                                                source.getType().getRank())) {
+            offsets.push_back(rewriter.getIndexAttr(0));
+            subSizes.push_back(sizes[index]);
+          }
+
+          SmallVector<OpFoldResult> strides(source.getType().getRank(),
+                                            rewriter.getIndexAttr(1));
+          auto sourceMemRefSlice = rewriter.create<memref::SubViewOp>(
+              loc, source, offsets, subSizes, strides);
+          rankReduce(sourceMemRefSlice);
+          auto destMemRefSlice = rewriter.create<memref::SubViewOp>(
+              loc, dest, offsets, subSizes, strides);
+          rankReduce(destMemRefSlice);
+          Value token = rewriter.create<StartTransferOp>(
+              op->getLoc(), sourceMemRefSlice, destMemRefSlice);
+          return {rewriter.create<CombineTokensOp>(
+              op->getLoc(), ValueRange{token, iterArgs.front()})};
+        });
+
+    rewriter.replaceOp(op, loopNest.results.front());
+    return success();
+  }
+};
+
+/// Add a contiguous inner unit dim if none exists.
+struct ExpandStartTransferOp : OpRewritePattern<StartTransferOp> {
+
+  using OpRewritePattern<StartTransferOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(StartTransferOp op,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<size_t> sourceNonContiguous =
+        getNumNonContiguousOuterDims(op.getSource().getType());
+    FailureOr<size_t> destNonContiguous =
+        getNumNonContiguousOuterDims(op.getDest().getType());
+    if (failed(sourceNonContiguous) || failed(destNonContiguous))
+      return failure();
+
+    size_t sharedNonContiguous =
+        std::max(*sourceNonContiguous, *destNonContiguous);
+
+    TypedValue<MemRefType> source = op.getSource();
+    TypedValue<MemRefType> dest = op.getDest();
+    // Nothing to do if contiguous inner dims exist.
+    if (sharedNonContiguous != source.getType().getRank())
+      return failure();
+
+    SmallVector<ReassociationIndices> reAssociation(sharedNonContiguous);
+    for (unsigned index : llvm::seq(sharedNonContiguous))
+      reAssociation[index].push_back(index);
+    reAssociation.back().push_back(sharedNonContiguous);
+
+    auto resultShape = llvm::to_vector(source.getType().getShape());
+    resultShape.push_back(1);
+
+    source = rewriter.create<memref::ExpandShapeOp>(op->getLoc(), resultShape,
+                                                    source, reAssociation);
+    dest = rewriter.create<memref::ExpandShapeOp>(op->getLoc(), resultShape,
+                                                  dest, reAssociation);
+
+    rewriter.replaceOpWithNewOp<StartTransferOp>(op, source, dest);
+    return success();
+  }
+};
+
+} // namespace
+
+void LegalizeDMAOperations::runOnOperation() {
+  ConversionTarget target(getContext());
+  target.markUnknownOpDynamicallyLegal([](auto &&...) { return true; });
+  target.addDynamicallyLegalOp<StartTransferOp>(
+      [](StartTransferOp op) { return isLegal(op); });
+
+  RewritePatternSet patterns(&getContext());
+  patterns.insert<CollapseStartTransferOp, RankReduceStartTransferOp,
+                  ExpandStartTransferOp>(&getContext());
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}

--- a/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/Passes.h
+++ b/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/Passes.h
@@ -1,0 +1,10 @@
+
+#pragma once
+
+#include <mlir/IR/BuiltinOps.h>
+#include <mlir/Pass/Pass.h>
+
+namespace quidditch::SnitchDMA {
+#define GEN_PASS_DECL
+#include "Quidditch/Dialect/SnitchDMA/Transforms/Passes.h.inc"
+} // namespace quidditch::Snitch

--- a/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/Passes.td
+++ b/codegen/compiler/src/Quidditch/Dialect/SnitchDMA/Transforms/Passes.td
@@ -1,0 +1,19 @@
+#ifndef QUIDDITCH_DIALECT_SNITCHDMA_TRANSFORMS_PASSES
+#define QUIDDITCH_DIALECT_SNITCHDMA_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def LegalizeDMAOperationsPass : Pass<"quidditch-snitch-legalize-dma-operations"> {
+  let description = [{
+
+  }];
+
+  let dependentDialects = [
+    "quidditch::dma::DMADialect",
+    "mlir::memref::MemRefDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::scf::SCFDialect",
+  ];
+}
+
+#endif

--- a/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
+++ b/codegen/compiler/src/Quidditch/Target/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
         ::Passes
         Quidditch::Conversion::ConvertToRISCV
         Quidditch::Dialect::Snitch::Transforms::Passes
+        Quidditch::Dialect::SnitchDMA::Transforms::Passes
         Quidditch::Dialect::DMA::Extensions::DMACoreSpecializationOpInterfaceImpl
         IREELinalgTransformDialect
         LLVMAnalysis

--- a/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
+++ b/codegen/compiler/src/Quidditch/Target/QuidditchTarget.cpp
@@ -32,6 +32,7 @@
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchOps.h"
 #include "Quidditch/Dialect/Snitch/Transforms/Passes.h"
 #include "Quidditch/Dialect/SnitchDMA/IR/SnitchDMADialect.h"
+#include "Quidditch/Dialect/SnitchDMA/Transforms/Passes.h"
 
 #include "compiler/plugins/target/LLVMCPU/LinkerTool.h"
 #include "compiler/plugins/target/LLVMCPU/StaticLibraryGenerator.h"
@@ -257,6 +258,7 @@ public:
 
     modulePassManager.addPass(quidditch::Snitch::createSpecializeDMACodePass());
     FunctionLikeNest(modulePassManager)
+        .addPass(quidditch::SnitchDMA::createLegalizeDMAOperationsPass)
         .addPass(createCanonicalizerPass)
         .addPass(createCSEPass);
     modulePassManager.addPass(quidditch::createConvertToRISCVPass(

--- a/codegen/tests/Conversion/ConvertDMAToLLVM/dma_transfer.mlir
+++ b/codegen/tests/Conversion/ConvertDMAToLLVM/dma_transfer.mlir
@@ -1,6 +1,6 @@
 // RUN: quidditch-opt %s --quidditch-convert-to-llvm | FileCheck %s
 
-// CHECK-LABEL: @test
+// CHECK-LABEL: @test1d(
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
@@ -8,197 +8,35 @@
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
-func.func private @test(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) -> !dma.token {
-  // CHECK: %[[ZERO:.*]] = llvm.mlir.zero
-  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[ZERO]][%[[ARG0_SIZE]]]
-  // CHECK: %[[SIZE:.*]] = llvm.ptrtoint %[[GEP]]
+func.func private @test1d(%arg0 : memref<?xf32>, %arg1 : memref<?xf32>) -> !dma.token {
+  // CHECK: %[[FOUR:.*]] = llvm.mlir.constant(4 :
+  // CHECK: %[[SIZE:.*]] = llvm.mul %[[ARG0_SIZE]], %[[FOUR]]
   // CHECK: %[[R:.*]] = llvm.call @snrt_dma_start_1d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[SIZE]])
   %0 = dma.start_transfer from %arg0 : memref<?xf32> to %arg1 : memref<?xf32>
   // CHECK: return %[[R]]
   return %0 : !dma.token
 }
 
-// CHECK-LABEL: @test2
+// CHECK-LABEL: @test2d(
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_SIZE:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_ALIGNED_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %[[ARG1_OFFSET:[[:alnum:]]+]]
-func.func private @test2(%arg0 : memref<?xf32>, %arg1 : memref<?xf32, strided<[1], offset: ?>>) -> !dma.token {
-  // CHECK: %[[ARG1_PTR:.*]] = llvm.getelementptr %[[ARG1_ALIGNED_PTR]][%[[ARG1_OFFSET]]]
-  // CHECK: %[[GEP:.*]] = llvm.getelementptr %{{.*}}[%[[ARG0_SIZE]]]
-  // CHECK: %[[SIZE:.*]] = llvm.ptrtoint %[[GEP]]
-  // CHECK: %[[R:.*]] = llvm.call @snrt_dma_start_1d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[SIZE]])
-  %0 = dma.start_transfer from %arg0 : memref<?xf32> to %arg1 : memref<?xf32, strided<[1], offset: ?>>
-  // CHECK: llvm.call @snrt_dma_start_1d(
-  %1 = dma.start_transfer from %arg1 : memref<?xf32, strided<[1], offset: ?>> to %arg0 : memref<?xf32>
-  return %0 : !dma.token
-}
-
-// CHECK-LABEL: @test3
-func.func private @test3(%arg0 : memref<?x4xf32>, %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>) -> !dma.token {
-  // CHECK: llvm.call @snrt_dma_start_1d(
-  %0 = dma.start_transfer from %arg0 : memref<?x4xf32> to %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>
-  return %0 : !dma.token
-}
-
-// CHECK-LABEL: @dynamic_inner(
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG0_DIM0:[[:alnum:]]+]]
 // CHECK-SAME: %[[ARG0_DIM1:[[:alnum:]]+]]
-func.func private @dynamic_inner(%subview_3 : memref<1x?xf64, strided<[161, 1], offset: ?>>, %subview_5 : memref<1x?xf64, strided<[81, 1]>>) {
-  // CHECK-DAG: %[[NULL:.*]] = llvm.mlir.zero
-  // CHECK-DAG: %[[ONE:.*]] = llvm.mlir.constant(1 :
-  // CHECK: %[[SIZE:.*]] = llvm.mul %[[ARG0_DIM1]], %[[ONE]]
-  // CHECK: %[[GEP:.*]] = llvm.getelementptr %[[NULL]][%[[SIZE]]]
-  // CHECK: %[[BYTES:.*]] = llvm.ptrtoint %[[GEP]]
-  // CHECK: call @snrt_dma_start_1d(
-  // CHECK-SAME: %{{[[:alnum:]]+}}
-  // CHECK-SAME: %{{[[:alnum:]]+}}
-  // CHECK-SAME: %[[BYTES]]
-  %12 = dma.start_transfer from %subview_3 : memref<1x?xf64, strided<[161, 1], offset: ?>> to %subview_5 : memref<1x?xf64, strided<[81, 1]>>
-  return
-}
-
-// CHECK-LABEL: @test4
-func.func private @test4(%arg0 : memref<1x4xf32>, %arg1 : memref<1x4xf32, strided<[40, 1], offset: ?>>) -> !dma.token {
-  // CHECK: llvm.call @snrt_dma_start_1d(
-  %0 = dma.start_transfer from %arg0 : memref<1x4xf32> to %arg1 : memref<1x4xf32, strided<[40, 1], offset: ?>>
-  return %0 : !dma.token
-}
-
-// CHECK-LABEL: @test5
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
-func.func private @test5(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>) -> !dma.token {
-  // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
-  // CHECK-DAG: %[[FOUR_INDEX:.*]] = llvm.mlir.constant(4 : index)
-  // CHECK-DAG: %[[TWO:.*]] = llvm.mlir.constant(2 : index)
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[TWO]])
-  %0 = dma.start_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>
-  return %0 : !dma.token
-}
-
-// CHECK-LABEL: @test6
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME:  %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG0_STRIDE0:[[:alnum:]]+]]
-// CHECK-SAME: %[[ARG0_STRIDE_N:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
+// CHECK-SAME: %[[ARG0_STRIDE1:[[:alnum:]]+]]
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %{{[[:alnum:]]+}}
 // CHECK-SAME: %[[ARG1_STRIDE0:[[:alnum:]]+]]
-// CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
-func.func private @test6(%arg0 : memref<3x2x4xf32>, %arg1 : memref<3x2x4xf32, strided<[16, 8, 1], offset: 2>>) -> !dma.token {
-  // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
-  // CHECK-DAG: %[[ZERO32:.*]] = llvm.mlir.constant(0 : i32) : i32
-  // CHECK-DAG: %[[ZERO:.*]] = llvm.mlir.constant(0 : index) : i32
-  // CHECK-DAG: %[[EIGHT:.*]] = llvm.mlir.constant(8 : {{.*}}) : i32
-  // CHECK-DAG: %[[SIXTEEN:.*]] = llvm.mlir.constant(16 : {{.*}}) : i32
-  // CHECK-DAG: %[[ONE:.*]] = llvm.mlir.constant(1 : {{.*}}) : i32
-  // CHECK-DAG: %[[TWO:.*]] = llvm.mlir.constant(2 : {{.*}}) : i32
-  // CHECK-DAG: %[[THREE:.*]] = llvm.mlir.constant(3 : {{.*}}) : i32
-  // CHECK-DAG: %[[FOUR_INDEX:.*]] = llvm.mlir.constant(4 : index)
-
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
-  // CHECK: llvm.br ^[[BB1:.*]](%[[ZERO]], %[[ZERO32]]
-
-  // CHECK: ^[[BB1]](%[[IV1:.*]]: i32, %[[IV2:.*]]: i32):
-  // CHECK: %[[COND:.*]] = llvm.icmp "slt" %[[IV1]], %[[THREE]]
-  // CHECK: llvm.cond_br %[[COND]], ^[[BODY:.*]], ^[[EXIT:[[:alnum:]]+]]
-
-  // CHECK: ^[[BODY]]:
-  // CHECK: %[[MUL1:.*]] = llvm.mul %[[IV1]], %[[EIGHT]]
-  // CHECK: %[[MUL2:.*]] = llvm.mul %[[IV1]], %[[SIXTEEN]]
-  // CHECK: %[[ARG0_OFFSET1:.*]] = llvm.add %[[MUL2]], %[[TWO]]
-  // CHECK: %[[ARG0_ADJUSTED:.*]] = llvm.getelementptr %[[ARG0_PTR]][%[[MUL1]]]
-  // CHECK: %[[ARG1_ADJUSTED:.*]] = llvm.getelementptr %[[ARG1_PTR]][%[[ARG0_OFFSET1]]]
-
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[FOUR_INDEX]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[EIGHT]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[RES:.*]] = llvm.call @snrt_dma_start_2d(%[[ARG1_ADJUSTED]], %[[ARG0_ADJUSTED]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[TWO]])
-  // CHECK: %[[INV:.*]] = llvm.add %[[IV1]], %[[ONE]]
-  // CHECK: llvm.br ^[[BB1]](%[[INV]], %[[RES]]
-
-  %0 = dma.start_transfer from %arg0 : memref<3x2x4xf32> to %arg1 : memref<3x2x4xf32, strided<[16, 8, 1], offset: 2>>
-  // CHECK: return %[[IV2]]
-  return %0 : !dma.token
-}
-
-
-// CHECK-LABEL: @dynamic_strides
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_SIZE:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_STRIDE_N:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
-func.func private @dynamic_strides(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[?, 1]>>) -> !dma.token {
-  // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
-  // CHECK-DAG: %[[FOUR:.*]] = llvm.mlir.constant(4 : index)
-  // CHECK-DAG: %[[TWO:.*]] = llvm.mlir.constant(2 : index)
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[FOUR]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[FOUR]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[TWO]])
-  %0 = dma.start_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[?, 1]>>
-  return %0 : !dma.token
-}
-
-// CHECK-LABEL: @contigious_dynamic_inner
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG0_SIZE:[[:alnum:]]+]]
-// CHECK-SAME: %[[ARG0_STRIDE_0:[[:alnum:]]+]]
-// CHECK-SAME: %[[ARG0_STRIDE_N:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_PTR:[[:alnum:]]+]]
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %{{[[:alnum:]]+}}
-// CHECK-SAME: %[[ARG1_STRIDE_N:[[:alnum:]]+]]
-func.func private @contigious_dynamic_inner(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32, strided<[?, 1]>>) -> !dma.token {
-  // CHECK: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 : i32)
-  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[ARG0_STRIDE_0]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE_N]], %[[ELEMENT_WIDTH]]
-  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[ARG0_SIZE]])
-  %0 = dma.start_transfer from %arg0 : memref<?x?xf32> to %arg1 : memref<?x?xf32, strided<[?, 1]>>
+func.func private @test2d(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>) -> !dma.token {
+  // CHECK-DAG: %[[ELEMENT_WIDTH:.*]] = llvm.mlir.constant(4 :
+  // CHECK: %[[INNER_SIZE:.*]] = llvm.mul %[[ARG0_DIM1]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG0_STRIDE:.*]] = llvm.mul %[[ARG0_STRIDE0]], %[[ELEMENT_WIDTH]]
+  // CHECK: %[[ARG1_STRIDE:.*]] = llvm.mul %[[ARG1_STRIDE0]], %[[ELEMENT_WIDTH]]
+  // CHECK: llvm.call @snrt_dma_start_2d(%[[ARG1_PTR]], %[[ARG0_PTR]], %[[INNER_SIZE]], %[[ARG1_STRIDE]], %[[ARG0_STRIDE]], %[[ARG0_DIM0]])
+  %0 = dma.start_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[8, 1], offset: 0>>
   return %0 : !dma.token
 }

--- a/codegen/tests/Dialect/SnitchDMA/Transforms/dma_transfer.mlir
+++ b/codegen/tests/Dialect/SnitchDMA/Transforms/dma_transfer.mlir
@@ -1,0 +1,85 @@
+// RUN: quidditch-opt %s --quidditch-snitch-legalize-dma-operations | FileCheck %s
+
+// CHECK-LABEL: @collapse(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+func.func private @collapse(%arg0 : memref<?x4xf32>, %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>) -> !dma.token {
+  // CHECK: %[[COLLAPSE_ARG0:.*]] = memref.collapse_shape %[[ARG0]]
+  // CHECK-SAME{LITERAL}: [[0, 1]]
+  // CHECK: %[[COLLAPSE_ARG1:.*]] = memref.collapse_shape %[[ARG1]]
+  // CHECK-SAME{LITERAL}: [[0, 1]]
+  // CHECK: %[[TOKEN:.*]] = dma.start_transfer
+  // CHECK-SAME: from %[[COLLAPSE_ARG0]]
+  // CHECK-SAME: to %[[COLLAPSE_ARG1]]
+  %0 = dma.start_transfer from %arg0 : memref<?x4xf32> to %arg1 : memref<?x4xf32, strided<[4, 1], offset: ?>>
+  // CHECK: return %[[TOKEN]]
+  return %0 : !dma.token
+}
+
+// CHECK-LABEL: @rank_reduction(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+func.func private @rank_reduction(%subview_3 : memref<1x?xf64, strided<[161, 1], offset: ?>>, %subview_5 : memref<1x?xf64, strided<[81, 1]>>) {
+  // CHECK: %[[ONE:.*]] = arith.constant 1
+  // CHECK: %[[DIM0:.*]] = memref.dim %[[ARG0]], %[[ONE]]
+  // CHECK: %[[ARG0_VIEW:.*]] = memref.subview %[[ARG0]][0, 0] [1, %[[DIM0]]] [1, 1]
+  // CHECK: %[[ARG1_VIEW:.*]] = memref.subview %[[ARG1]][0, 0] [1, %[[DIM0]]] [1, 1]
+  // CHECK: dma.start_transfer
+  // CHECK-SAME: from %[[ARG0_VIEW]]
+  // CHECK-SAME: to %[[ARG1_VIEW]]
+  %12 = dma.start_transfer from %subview_3 : memref<1x?xf64, strided<[161, 1], offset: ?>> to %subview_5 : memref<1x?xf64, strided<[81, 1]>>
+  return
+}
+
+// CHECK-LABEL: @legal_2d(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+func.func private @legal_2d(%arg0 : memref<2x4xf32>, %arg1 : memref<2x4xf32, strided<[8, 1]>>) -> !dma.token {
+  // CHECK: dma.start_transfer
+  // CHECK-SAME: from %[[ARG0]]
+  // CHECK-SAME: to %[[ARG1]]
+  %0 = dma.start_transfer from %arg0 : memref<2x4xf32> to %arg1 : memref<2x4xf32, strided<[8, 1]>>
+  return %0 : !dma.token
+}
+
+// CHECK-LABEL: @transfer_3d(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+func.func private @transfer_3d(%arg0 : memref<3x2x4xf32>, %arg1 : memref<3x2x4xf32, strided<[16, 8, 1], offset: 2>>) -> !dma.token {
+  // CHECK-DAG: %[[ZERO:.*]] = arith.constant 0
+  // CHECK-DAG: %[[ONE:.*]] = arith.constant 1
+  // CHECK-DAG: %[[THREE:.*]] = arith.constant 3
+  // CHECK: %[[TOKEN:.*]] = dma.completed_token
+  // CHECK: %[[FOR:.*]] = scf.for %[[IV:.*]] = %[[ZERO]] to %[[THREE]] step %[[ONE]] iter_args(%[[ITER:.*]] = %[[TOKEN]])
+  // CHECK:   %[[SOURCE_VIEW:.*]] = memref.subview %[[ARG0]][%[[IV]], 0, 0] [1, 2, 4] [1, 1, 1]
+  // CHECK:   %[[DEST_VIEW:.*]] = memref.subview %[[ARG1]][%[[IV]], 0, 0] [1, 2, 4] [1, 1, 1]
+  // CHECK:   %[[TOKEN2:.*]] = dma.start_transfer
+  // CHECK-SAME: from %[[SOURCE_VIEW]]
+  // CHECK-SAME: to %[[DEST_VIEW]]
+  // CHECK:   %[[COMBINED:.*]] = dma.combine_tokens %[[TOKEN2]], %[[ITER]]
+  // CHECK:   scf.yield %[[COMBINED]]
+  %0 = dma.start_transfer from %arg0 : memref<3x2x4xf32> to %arg1 : memref<3x2x4xf32, strided<[16, 8, 1], offset: 2>>
+  // CHECK: return %[[FOR]]
+  return %0 : !dma.token
+}
+
+// CHECK-LABEL: @illegal_1d(
+// CHECK-SAME: %[[ARG0:[[:alnum:]]+]]
+// CHECK-SAME: %[[ARG1:[[:alnum:]]+]]
+func.func private @illegal_1d(%arg0 : memref<?xf32>, %arg1 : memref<?xf32, strided<[?]>>) -> !dma.token {
+  // CHECK: %[[ZERO:.*]] = arith.constant 0
+  // CHECK: %[[DIM0:.*]] = memref.dim %[[ARG0]], %[[ZERO]]
+  // CHECK: %[[EXPAND_ARG0:.*]] = memref.expand_shape %[[ARG0]]
+  // CHECK-SAME{LITERAL}: [[0, 1]]
+  // CHECK-SAME: output_shape [%[[DIM0]], 1]
+  // CHECK: %[[ZERO:.*]] = arith.constant 0
+  // CHECK: %[[DIM0:.*]] = memref.dim %[[ARG1]], %[[ZERO]]
+  // CHECK: %[[EXPAND_ARG1:.*]] = memref.expand_shape %[[ARG1]]
+  // CHECK-SAME{LITERAL}: [[0, 1]]
+  // CHECK-SAME: output_shape [%[[DIM0]], 1]
+  // CHECK: %[[TOKEN:.*]] = dma.start_transfer
+  // CHECK-SAME: from %[[EXPAND_ARG0]]
+  // CHECK-SAME: to %[[EXPAND_ARG1]]
+  %0 = dma.start_transfer from %arg0 : memref<?xf32> to %arg1 : memref<?xf32, strided<[?]>>
+  return %0 : !dma.token
+}

--- a/codegen/tools/CMakeLists.txt
+++ b/codegen/tools/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(quidditch-opt
         Quidditch::Conversion::ConvertToRISCV
         Quidditch::Dialect::DMA::Extensions::DMACoreSpecializationOpInterfaceImpl
         Quidditch::Dialect::SnitchDMA::IR::SnitchDMADialect
+        Quidditch::Dialect::SnitchDMA::Transforms::Passes
         Quidditch::Dialect::Snitch::IR::QuidditchSnitchDialect
         Quidditch::Dialect::Snitch::Transforms::Passes
         Quidditch::Target::Passes

--- a/codegen/tools/quidditch-opt.cpp
+++ b/codegen/tools/quidditch-opt.cpp
@@ -4,9 +4,10 @@
 #include "Quidditch/Conversion/Passes.h"
 #include "Quidditch/Dialect/DMA/Extensions/DMACoreSpecializationOpInterfaceImpl.h"
 #include "Quidditch/Dialect/DMA/IR/DMADialect.h"
-#include "Quidditch/Dialect/SnitchDMA/IR/SnitchDMADialect.h"
 #include "Quidditch/Dialect/Snitch/IR/QuidditchSnitchDialect.h"
 #include "Quidditch/Dialect/Snitch/Transforms/Passes.h"
+#include "Quidditch/Dialect/SnitchDMA/IR/SnitchDMADialect.h"
+#include "Quidditch/Dialect/SnitchDMA/Transforms/Passes.h"
 #include "Quidditch/Target/Passes.h"
 
 #include "mlir/Dialect/Bufferization/Transforms/Passes.h"
@@ -21,6 +22,10 @@ namespace Snitch {
 #define GEN_PASS_REGISTRATION
 #include "Quidditch/Dialect/Snitch/Transforms/Passes.h.inc"
 } // namespace Snitch
+namespace SnitchDMA {
+#define GEN_PASS_REGISTRATION
+#include "Quidditch/Dialect/SnitchDMA/Transforms/Passes.h.inc"
+} // namespace SnitchDMA
 } // namespace quidditch
 
 using namespace mlir;
@@ -38,6 +43,7 @@ int main(int argc, char **argv) {
   quidditch::registerPasses();
   quidditch::registerConversionPasses();
   quidditch::Snitch::registerTransformsPasses();
+  quidditch::SnitchDMA::registerTransformsPasses();
   mlir::bufferization::registerBufferizationPasses();
   mlir::registerTransformsPasses();
 


### PR DESCRIPTION
It is up to the target, in this case snitch, to dictate which DMA transfers are directly legal or not. This logic previously lived in `DMAToLLVM` and due to being part of the "one-shot-to-llvm" pass, difficult to test and implement.

This PR therefore splits the logic into a dedicated legalization pass with the lowering to LLVM greatly simplified.