### PR TITLE
remove aligning to default alignment

### DIFF
--- a/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerL1Allocations.cpp
+++ b/codegen/compiler/src/Quidditch/Dialect/Snitch/Transforms/LowerL1Allocations.cpp
@@ -55,11 +55,9 @@ void LowerL1Allocations::runOnOperation() {
     builder.setInsertionPoint(allocOp);
     MemRefType memRefType = allocOp.getType();
     // Note: This assumes bitWidth == alignment == size.
+    // Since we use a scratchpad, align to size of element in bytes.
     uint64_t bitWidth = memRefType.getElementTypeBitWidth();
-    if (std::optional<uint64_t> alignment = allocOp.getAlignment())
-      offset = llvm::alignTo(offset, *alignment);
-    else
-      offset = llvm::alignTo(offset, llvm::divideCeil(bitWidth, 8));
+    offset = llvm::alignTo(offset, llvm::divideCeil(bitWidth, 8));
 
     auto byteShift =
         builder.create<arith::ConstantIndexOp>(allocOp.getLoc(), offset);


### PR DESCRIPTION
- Ensures L1-assigned allocOps get aligned to their element size in bytes
- Removes aligning these allocOps to the value returned by their getAlignment() method, which might be set to 64 bytes by default (due to most CPUs' cachelines being 64 bytes)