### PR TITLE
tile-size-0-40-100-failure

### DIFF
--- a/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
+++ b/codegen/compiler/src/Quidditch/Target/ConfigureForSnitch.cpp
@@ -63,7 +63,7 @@ static LogicalResult setRootConfig(FunctionOpInterface funcOp,
         if (funcOp.getName() ==
             "main$async_dispatch_9_matmul_transpose_b_1x161x600_f64") {
           l1Tiles[0] = 0;
-          l1Tiles[1] = 56;
+          l1Tiles[1] = 40;
           l1Tiles[2] = 100;
         }
         if (funcOp.getName() ==


### PR DESCRIPTION
- Changing dispatch 9's tile size from 56x100 to 40x100 causes a build error.
- This must be a bug, because 40x100 is smaller than 56x100, meaning it definitely fits in L1 (tile size is not too big).
- Full build output attached: [dispatch-9-build-error.txt](https://github.com/user-attachments/files/19792267/dispatch-9-build-error.txt)
