### PR TITLE
illustrate unnecessary pad operation

### DIFF
--- a/codegen/compiler/src/Quidditch/Target/PadToTilingConfig.cpp
+++ b/codegen/compiler/src/Quidditch/Target/PadToTilingConfig.cpp
@@ -403,10 +403,12 @@ void PadToTilingConfig::runOnOperation() {
   std::optional<IntegerAttr> attr = getConfigIntegerAttr(
       IREE::HAL::ExecutableTargetAttr::lookup(getOperation()), "compute_cores");
 
+  getOperation()->emitWarning()<< "\nvvv before padding vvv";
   // Pad every linalg op to a multiple of all applied tile sizes.
   for (linalg::LinalgOp &linalgOp : workList)
     if (failed(padToTileSize(linalgOp, attr)))
       return signalPassFailure();
+  getOperation()->emitWarning()<< "\nvvv after padding vvv";
 
   // First perform just the conversion of zero-pads to undef-pads.
   // These must run separately from later patterns that may erase pad ops


### PR DESCRIPTION
- Creating this PR to more clearly illustrate issue #142 
- For example, an unnecessary padOp gets created when padding dispatch 9:
```
  %cst = arith.constant 0.000000e+00 : f64
  ... // omitted some IR here for brevity
  %8 = tensor.empty() : tensor<1x161xf64>
  %cst_1 = arith.constant 0.000000e+00 : f64
  %padded = tensor.pad %8 low[0, 0] high[0, 7] {
  ^bb0(%arg0: index, %arg1: index):
    tensor.yield %cst_1 : f64
  } : tensor<1x161xf64> to tensor<1x168xf64>
  %9 = linalg.fill ins(%cst : f64) outs(%padded : tensor<1x168xf64>) -> tensor<1x168xf64>
```
**Instead of creating a tensor of size 1x161, padding it to 1x168 and then filling that tensor with zeroes, we should just create an empty tensor of 1x168 and fill with zeroes (no padding operation).** It's important to remove the unnecessary padding operation, because later at bufferization, this results in an extra allocOp in L1 that we do not need.
- output for just dispatch 9 here: 
[dispatch-9-build-error.txt](https://github.com/user-attachments/files/19793482/dispatch-9-build-error.txt)
- full build output here: 
[build-output-with-padding.txt](https://github.com/user-attachments/files/19793319/build-output-with-padding.txt)